### PR TITLE
Device capability flags: restrict POS devices to sales and/or topup

### DIFF
--- a/app/Http/DeviceApi/V1/Controllers/TransactionController.php
+++ b/app/Http/DeviceApi/V1/Controllers/TransactionController.php
@@ -70,7 +70,8 @@ class TransactionController extends \App\Http\Shared\V1\Controllers\TransactionC
         $writeContext = $this->getContext(Action::CREATE);
         $resources = $this->bodyToResources($writeContext, TransactionResourceDefinition::class);
 
-        $transactionMerger = new TransactionMerger($organisation);
+        $uploadingDevice = $request->user() instanceof \App\Models\Device ? $request->user() : null;
+        $transactionMerger = new TransactionMerger($organisation, $uploadingDevice);
 
         $entities = [];
         foreach ($resources as $resource) {

--- a/app/Http/DeviceApi/V1/ResourceDefinitions/DeviceResourceDefinition.php
+++ b/app/Http/DeviceApi/V1/ResourceDefinitions/DeviceResourceDefinition.php
@@ -73,6 +73,14 @@ class DeviceResourceDefinition extends ResourceDefinition
 			->visible(true)
 			->writeable(true, true);
 
+		$this->field('allow_sales')
+			->bool()
+			->visible(true);
+
+		$this->field('allow_topup')
+			->bool()
+			->visible(true);
+
 		$this->field('isOnline')
 			->display('is_online')
 			->bool()

--- a/app/Http/DeviceApi/V1/ResourceDefinitions/TransactionResourceDefinition.php
+++ b/app/Http/DeviceApi/V1/ResourceDefinitions/TransactionResourceDefinition.php
@@ -109,6 +109,10 @@ class TransactionResourceDefinition extends ResourceDefinition
             ->writeable(true, true)
             ->visible(true);
 
+        $this->field('unauthorized')
+            ->bool()
+            ->visible(true);
+
         $this->field('created_at')
             ->datetime(DateTimeTransformer::class)
             ->visible(true);

--- a/app/Http/ManagementApi/V1/ResourceDefinitions/DeviceResourceDefinition.php
+++ b/app/Http/ManagementApi/V1/ResourceDefinitions/DeviceResourceDefinition.php
@@ -104,6 +104,16 @@ class DeviceResourceDefinition extends ResourceDefinition
             ->visible(true)
             ->writeable(true, true);
 
+        $this->field('allow_sales')
+            ->bool()
+            ->visible(true)
+            ->writeable(true, true);
+
+        $this->field('allow_topup')
+            ->bool()
+            ->visible(true)
+            ->writeable(true, true);
+
         $this->field('pendingOrdersCount')
             ->display('pending_orders_count')
             ->number()

--- a/app/Models/Device.php
+++ b/app/Models/Device.php
@@ -28,6 +28,8 @@ class Device extends Model implements
 		'category_filter_id',
 		'allow_remote_orders',
 		'allow_live_orders',
+		'allow_sales',
+		'allow_topup',
 	];
 
 	protected $casts = [
@@ -35,6 +37,8 @@ class Device extends Model implements
 		'last_activity' => 'datetime',
 		'allow_remote_orders' => 'boolean',
 		'allow_live_orders' => 'boolean',
+		'allow_sales' => 'boolean',
+		'allow_topup' => 'boolean',
 		'approved_at' => 'datetime',
 	];
 
@@ -77,7 +81,8 @@ class Device extends Model implements
 
 			// If settings affecting order assignment changed, re-evaluate assignments
 			$needsReassignment = $device->wasChanged('category_filter_id')
-				|| ($device->wasChanged('allow_remote_orders') && !$device->allow_remote_orders);
+				|| ($device->wasChanged('allow_remote_orders') && !$device->allow_remote_orders)
+				|| ($device->wasChanged('allow_sales') && !$device->allow_sales);
 
 			if ($needsReassignment) {
 				$assignmentService = new \App\Services\OrderAssignmentService();

--- a/app/Models/Transaction.php
+++ b/app/Models/Transaction.php
@@ -81,6 +81,10 @@ class Transaction extends Model
         'value'
     ];
 
+    protected $casts = [
+        'unauthorized' => 'boolean',
+    ];
+
     /**
      * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
@@ -111,6 +115,15 @@ class Transaction extends Model
     public function topup()
     {
         return $this->belongsTo(Topup::class);
+    }
+
+    /**
+     * The device that uploaded this transaction to the server.
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function uploadedByDevice()
+    {
+        return $this->belongsTo(Device::class, 'uploaded_by_device_id');
     }
 
     /**

--- a/app/Services/OrderAssignmentService.php
+++ b/app/Services/OrderAssignmentService.php
@@ -90,8 +90,8 @@ class OrderAssignmentService
 					// If this order belongs to the device that just changed its settings,
 					// check if the device still accepts this order
 					if ($changedDevice && $device->id === $changedDevice->id) {
-						// Device disabled remote orders — must reassign
-						if (!$device->allow_remote_orders) {
+						// Device disabled remote orders or sales — must reassign
+						if (!$device->allow_remote_orders || !$device->allow_sales) {
 							// Fall through to reassign
 						} else {
 							$orderCategoryIds = $this->getOrderCategoryIds($order);
@@ -183,6 +183,7 @@ class OrderAssignmentService
 		$onlineDevices = Device::where('organisation_id', $event->organisation_id)
 			->where('last_ping', '>', $cutoff)
 			->where('allow_remote_orders', true)
+			->where('allow_sales', true)
 			->get();
 
 		if ($onlineDevices->isEmpty()) {

--- a/app/Tools/TransactionMerger.php
+++ b/app/Tools/TransactionMerger.php
@@ -149,13 +149,19 @@ class TransactionMerger
 
                 // Devices without topup permission cannot legitimately produce
                 // balance-adding transactions; keep them but mark for review.
+                // Any other positive-value upload that isn't a reversal is also
+                // never legitimate from a sales-only device (a mistyped/unknown
+                // transaction_type shouldn't slip past the type-list check above).
                 if (
                     !$this->uploadingDevice->allow_topup &&
-                    in_array($entity->transaction_type, [
-                        Transaction::TYPE_TOPUP,
-                        Transaction::TYPE_RESET,
-                        Transaction::TYPE_REFUND,
-                    ])
+                    (
+                        in_array($entity->transaction_type, [
+                            Transaction::TYPE_TOPUP,
+                            Transaction::TYPE_RESET,
+                            Transaction::TYPE_REFUND,
+                        ]) ||
+                        ($entity->value > 0 && $entity->transaction_type !== Transaction::TYPE_REVERSAL)
+                    )
                 ) {
                     $transaction->unauthorized = true;
                 }

--- a/app/Tools/TransactionMerger.php
+++ b/app/Tools/TransactionMerger.php
@@ -24,6 +24,7 @@ namespace App\Tools;
 
 use App\Exceptions\TransactionMergeException;
 use App\Models\Card;
+use App\Models\Device;
 use App\Models\Organisation;
 use App\Models\Transaction;
 use CatLab\Charon\Exceptions\EntityNotFoundException;
@@ -52,9 +53,15 @@ class TransactionMerger
      */
     private $cards = [];
 
-    public function __construct(Organisation $organisation)
+    /**
+     * @var Device|null
+     */
+    private $uploadingDevice;
+
+    public function __construct(Organisation $organisation, ?Device $uploadingDevice = null)
     {
         $this->organisation = $organisation;
+        $this->uploadingDevice = $uploadingDevice;
     }
 
     /**
@@ -134,6 +141,25 @@ class TransactionMerger
 
         try {
             $transaction->mergeFromTransaction($entity);
+
+            if ($this->uploadingDevice) {
+                if (!$transaction->uploaded_by_device_id) {
+                    $transaction->uploaded_by_device_id = $this->uploadingDevice->id;
+                }
+
+                // Devices without topup permission cannot legitimately produce
+                // balance-adding transactions; keep them but mark for review.
+                if (
+                    !$this->uploadingDevice->allow_topup &&
+                    in_array($entity->transaction_type, [
+                        Transaction::TYPE_TOPUP,
+                        Transaction::TYPE_RESET,
+                        Transaction::TYPE_REFUND,
+                    ])
+                ) {
+                    $transaction->unauthorized = true;
+                }
+            }
 
             // Is this transaction new and is the card transaction count lower than this transaction?
             if (!$transaction->exists && $card->transaction_count < $transaction->card_sync_id) {

--- a/database/migrations/2026_07_08_100000_add_capability_flags_to_devices.php
+++ b/database/migrations/2026_07_08_100000_add_capability_flags_to_devices.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+	/**
+	 * Run the migrations.
+	 *
+	 * @return void
+	 */
+	public function up()
+	{
+		Schema::table('devices', function (Blueprint $table) {
+			$table->boolean('allow_sales')->default(true)->after('allow_live_orders');
+			$table->boolean('allow_topup')->default(true)->after('allow_sales');
+		});
+	}
+
+	/**
+	 * Reverse the migrations.
+	 *
+	 * @return void
+	 */
+	public function down()
+	{
+		Schema::table('devices', function (Blueprint $table) {
+			$table->dropColumn('allow_sales');
+			$table->dropColumn('allow_topup');
+		});
+	}
+};

--- a/database/migrations/2026_07_08_100001_add_upload_audit_to_card_transactions.php
+++ b/database/migrations/2026_07_08_100001_add_upload_audit_to_card_transactions.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+	/**
+	 * Run the migrations.
+	 *
+	 * @return void
+	 */
+	public function up()
+	{
+		Schema::table('card_transactions', function (Blueprint $table) {
+			$table->unsignedBigInteger('uploaded_by_device_id')->nullable();
+			$table->foreign('uploaded_by_device_id')->references('id')->on('devices')->nullOnDelete();
+			$table->boolean('unauthorized')->default(false);
+		});
+	}
+
+	/**
+	 * Reverse the migrations.
+	 *
+	 * @return void
+	 */
+	public function down()
+	{
+		Schema::table('card_transactions', function (Blueprint $table) {
+			$table->dropForeign(['uploaded_by_device_id']);
+			$table->dropColumn('uploaded_by_device_id');
+			$table->dropColumn('unauthorized');
+		});
+	}
+};

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,5 +34,43 @@ services:
       timeout: 5s
       retries: 30
 
+  # Throwaway MySQL for the PHPUnit feature tests (mirrors the CI service in
+  # .github/workflows/tests.yml). Data lives in tmpfs: nothing persists.
+  # Usage: docker compose run --rm phpunit [phpunit args]
+  # (or from the host, if php-mysql is installed: DB_PORT=3313 vendor/bin/phpunit)
+  mysql-test:
+    image: mysql:8.0
+    profiles: ["test"]
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: catlab_drinks_test
+      MYSQL_USER: test
+      MYSQL_PASSWORD: test
+    ports:
+      - "127.0.0.1:3313:3306"
+    tmpfs:
+      - /var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "root", "-proot"]
+      interval: 5s
+      timeout: 5s
+      retries: 30
+
+  # Containerized PHPUnit runner: no PHP extensions needed on the host.
+  phpunit:
+    image: thecodingmachine/php:8.1-v5-cli
+    profiles: ["test"]
+    working_dir: /var/www/html
+    volumes:
+      - ./:/var/www/html
+    environment:
+      PHP_EXTENSION_PDO_MYSQL: "1"
+      DB_HOST: mysql-test
+      DB_PORT: 3306
+    depends_on:
+      mysql-test:
+        condition: service_healthy
+    entrypoint: ["php", "vendor/bin/phpunit"]
+
 volumes:
   mysql-data:

--- a/docs/superpowers/plans/2026-07-08-device-capability-flags.md
+++ b/docs/superpowers/plans/2026-07-08-device-capability-flags.md
@@ -1,0 +1,1146 @@
+# Device Capability Flags (sales / topup) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Admin-controlled `allow_sales` / `allow_topup` flags per POS device, so bar devices can be locked out of card topup/reset while topup stations can be locked out of sales — with server-side audit flagging of unauthorized topup transactions.
+
+**Architecture:** Two boolean columns on `devices`, writeable only through the Management API (Device API exposes them read-only). The POS reads the flags at boot from `GET /pos-api/v1/devices/current` and gates navigation with a Vue Router guard. Because card writes happen offline with the device signing key, the server does not reject rogue topups — it marks them `unauthorized` at upload time (`merge-transactions` endpoint) for admin review.
+
+**Tech Stack:** Laravel 8-style backend with CatLab Charon REST framework, Vue 3 (@vue/compat) + Bootstrap-Vue frontends, Laravel Mix build, Vitest for JS route/guard tests.
+
+**Spec:** `docs/superpowers/specs/2026-07-08-device-capability-flags-design.md`
+
+## Global Constraints
+
+- Never run `npm update`; use `npm install` only. Never commit `package-lock.json` changes — run `git checkout -- package-lock.json` before committing.
+- PHP deps: lock file requires PHP ~8.1/~8.2; use `composer install --ignore-platform-reqs` if needed (vendor/ is already installed).
+- No PHP test suite exists — backend tasks are verified manually via `php artisan migrate`, `php artisan route:list`, and `php artisan tinker`. The local MySQL comes from `docker-compose.yml`; run `docker compose up -d` if the DB is not running.
+- JS tests: `npx vitest run` (route/view tests), `npx jest` (NFC tests). Both must pass before every commit that touches JS.
+- All user-facing strings go through `$t('...')` and must be added to **all five** locale files: `resources/shared/js/i18n/{en,nl,fr,de,es}.js` (identical key sets; keys are the English strings).
+- Tabs for indentation in PHP and Vue files (match existing files).
+- Both new device flags default to `true` — existing devices must keep working unchanged after migration.
+- End every commit message with:
+  ```
+  Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+  Claude-Session: https://claude.ai/code/session_01RQjdQhQM3q7MZCWCv3AdmD
+  ```
+  (The plan's `git commit -m` commands omit this for brevity — always append it.)
+
+---
+
+### Task 1: Device capability columns + model
+
+**Files:**
+- Create: `database/migrations/2026_07_08_100000_add_capability_flags_to_devices.php`
+- Modify: `app/Models/Device.php:24-39` (fillable/casts), `app/Models/Device.php:78-88` (updated hook)
+
+**Interfaces:**
+- Produces: `Device::$allow_sales` (bool, default true), `Device::$allow_topup` (bool, default true) — used by Tasks 3, 4, 5.
+
+- [ ] **Step 1: Write the migration**
+
+Create `database/migrations/2026_07_08_100000_add_capability_flags_to_devices.php`:
+
+```php
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+	/**
+	 * Run the migrations.
+	 *
+	 * @return void
+	 */
+	public function up()
+	{
+		Schema::table('devices', function (Blueprint $table) {
+			$table->boolean('allow_sales')->default(true)->after('allow_live_orders');
+			$table->boolean('allow_topup')->default(true)->after('allow_sales');
+		});
+	}
+
+	/**
+	 * Reverse the migrations.
+	 *
+	 * @return void
+	 */
+	public function down()
+	{
+		Schema::table('devices', function (Blueprint $table) {
+			$table->dropColumn('allow_sales');
+			$table->dropColumn('allow_topup');
+		});
+	}
+};
+```
+
+- [ ] **Step 2: Update the Device model**
+
+In `app/Models/Device.php`, extend `$fillable` and `$casts`:
+
+```php
+	protected $fillable = [
+		'uid',
+		'name',
+		'secret_key',
+		'category_filter_id',
+		'allow_remote_orders',
+		'allow_live_orders',
+		'allow_sales',
+		'allow_topup',
+	];
+
+	protected $casts = [
+		'last_ping' => 'datetime',
+		'last_activity' => 'datetime',
+		'allow_remote_orders' => 'boolean',
+		'allow_live_orders' => 'boolean',
+		'allow_sales' => 'boolean',
+		'allow_topup' => 'boolean',
+		'approved_at' => 'datetime',
+	];
+```
+
+In the `static::updated` hook (currently around line 78), extend the reassignment condition so switching sales off reassigns that device's pending remote orders:
+
+```php
+			// If settings affecting order assignment changed, re-evaluate assignments
+			$needsReassignment = $device->wasChanged('category_filter_id')
+				|| ($device->wasChanged('allow_remote_orders') && !$device->allow_remote_orders)
+				|| ($device->wasChanged('allow_sales') && !$device->allow_sales);
+```
+
+- [ ] **Step 3: Run the migration and verify**
+
+```bash
+docker compose up -d   # only if DB not already running
+php artisan migrate
+```
+Expected: `2026_07_08_100000_add_capability_flags_to_devices ... DONE`
+
+Verify defaults with tinker:
+
+```bash
+php artisan tinker --execute="var_dump(\App\Models\Device::query()->first()?->allow_sales, \App\Models\Device::query()->first()?->allow_topup);"
+```
+Expected: `bool(true)` twice (or `NULL NULL` if the table is empty — then just check the columns exist: `php artisan tinker --execute="var_dump(\Illuminate\Support\Facades\Schema::hasColumns('devices', ['allow_sales','allow_topup']));"` → `bool(true)`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add database/migrations/2026_07_08_100000_add_capability_flags_to_devices.php app/Models/Device.php
+git commit -m "Add allow_sales/allow_topup capability flags to devices"
+```
+
+---
+
+### Task 2: Transaction audit columns + model
+
+**Files:**
+- Create: `database/migrations/2026_07_08_100001_add_upload_audit_to_card_transactions.php`
+- Modify: `app/Models/Transaction.php` (casts + relationship)
+
+**Interfaces:**
+- Produces: `Transaction::$uploaded_by_device_id` (nullable FK), `Transaction::$unauthorized` (bool, default false), `Transaction::uploadedByDevice()` relation — used by Tasks 3 and 4.
+
+- [ ] **Step 1: Write the migration**
+
+Create `database/migrations/2026_07_08_100001_add_upload_audit_to_card_transactions.php`:
+
+```php
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+	/**
+	 * Run the migrations.
+	 *
+	 * @return void
+	 */
+	public function up()
+	{
+		Schema::table('card_transactions', function (Blueprint $table) {
+			$table->unsignedBigInteger('uploaded_by_device_id')->nullable();
+			$table->foreign('uploaded_by_device_id')->references('id')->on('devices')->nullOnDelete();
+			$table->boolean('unauthorized')->default(false);
+		});
+	}
+
+	/**
+	 * Reverse the migrations.
+	 *
+	 * @return void
+	 */
+	public function down()
+	{
+		Schema::table('card_transactions', function (Blueprint $table) {
+			$table->dropForeign(['uploaded_by_device_id']);
+			$table->dropColumn('uploaded_by_device_id');
+			$table->dropColumn('unauthorized');
+		});
+	}
+};
+```
+
+- [ ] **Step 2: Update the Transaction model**
+
+In `app/Models/Transaction.php`, add a `$casts` property (the model currently has none) right after `$fillable`, and add the relationship method after the existing `topup()` method:
+
+```php
+    protected $casts = [
+        'unauthorized' => 'boolean',
+    ];
+```
+
+```php
+    /**
+     * The device that uploaded this transaction to the server.
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function uploadedByDevice()
+    {
+        return $this->belongsTo(Device::class, 'uploaded_by_device_id');
+    }
+```
+
+Add `use App\Models\Device;` only if the model isn't already in the same namespace — it is (`App\Models`), so no import is needed.
+
+- [ ] **Step 3: Run the migration and verify**
+
+```bash
+php artisan migrate
+php artisan tinker --execute="var_dump(\Illuminate\Support\Facades\Schema::hasColumns('card_transactions', ['uploaded_by_device_id','unauthorized']));"
+```
+Expected: `bool(true)`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add database/migrations/2026_07_08_100001_add_upload_audit_to_card_transactions.php app/Models/Transaction.php
+git commit -m "Add upload audit columns to card_transactions"
+```
+
+---
+
+### Task 3: API exposure — Management writeable, Device API read-only
+
+**Files:**
+- Modify: `app/Http/ManagementApi/V1/ResourceDefinitions/DeviceResourceDefinition.php:97-105`
+- Modify: `app/Http/DeviceApi/V1/ResourceDefinitions/DeviceResourceDefinition.php:66-74`
+- Modify: `app/Http/DeviceApi/V1/ResourceDefinitions/TransactionResourceDefinition.php:112-118`
+
+**Interfaces:**
+- Consumes: model fields from Tasks 1–2.
+- Produces: `allow_sales`/`allow_topup` in Management API device resources (writeable) and in `GET /pos-api/v1/devices/current` (read-only); `unauthorized` field visible on transaction resources (both APIs share this definition). Task 6 writes these fields; Task 7 reads them; Task 9 reads `unauthorized`.
+
+**Security note:** In the Device API definition the new fields get NO `writeable()` call — Charon fields are non-writeable by default, which is exactly what makes `PUT /pos-api/v1/devices/current` ignore them.
+
+- [ ] **Step 1: Management API — add writeable fields**
+
+In `app/Http/ManagementApi/V1/ResourceDefinitions/DeviceResourceDefinition.php`, after the `allow_live_orders` field block (line ~102), add:
+
+```php
+        $this->field('allow_sales')
+            ->bool()
+            ->visible(true)
+            ->writeable(true, true);
+
+        $this->field('allow_topup')
+            ->bool()
+            ->visible(true)
+            ->writeable(true, true);
+```
+
+- [ ] **Step 2: Device API — add read-only fields**
+
+In `app/Http/DeviceApi/V1/ResourceDefinitions/DeviceResourceDefinition.php`, after the `allow_live_orders` field block (line ~71), add:
+
+```php
+		$this->field('allow_sales')
+			->bool()
+			->visible(true)
+			->writeable(false);
+
+		$this->field('allow_topup')
+			->bool()
+			->visible(true)
+			->writeable(false);
+```
+
+- [ ] **Step 3: Expose `unauthorized` on transactions**
+
+In `app/Http/DeviceApi/V1/ResourceDefinitions/TransactionResourceDefinition.php` (shared by both APIs via the Shared TransactionController), after the `client_date` field block (line ~110), add:
+
+```php
+        $this->field('unauthorized')
+            ->bool()
+            ->visible(true);
+```
+
+- [ ] **Step 4: Verify routes still register**
+
+```bash
+php artisan route:list --path=pos-api | head -30
+php artisan route:list --path=api/v1/devices
+```
+Expected: routes list without errors (a Charon definition typo throws during route registration).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/Http/ManagementApi/V1/ResourceDefinitions/DeviceResourceDefinition.php app/Http/DeviceApi/V1/ResourceDefinitions/DeviceResourceDefinition.php app/Http/DeviceApi/V1/ResourceDefinitions/TransactionResourceDefinition.php
+git commit -m "Expose capability flags via APIs (admin-writeable, device read-only)"
+```
+
+---
+
+### Task 4: Flag unauthorized topups at upload (TransactionMerger)
+
+**Files:**
+- Modify: `app/Tools/TransactionMerger.php`
+- Modify: `app/Http/DeviceApi/V1/Controllers/TransactionController.php:64-73`
+
+**Interfaces:**
+- Consumes: `Device::$allow_topup`, `Transaction::$uploaded_by_device_id`, `Transaction::$unauthorized` (Tasks 1–2).
+- Produces: `TransactionMerger::__construct(Organisation $organisation, ?Device $uploadingDevice = null)` — new optional second parameter. All other callers keep working (search confirmed the only instantiation is in the Device API TransactionController).
+
+**Background (why here):** All typed transactions (topup/reset/sale/refund) reach the server exclusively through `POST /pos-api/v1/organisations/{id}/merge-transactions`, and each device only uploads transactions it performed itself (they come from its local pending queue). Second-hand card observations arrive via the separate card-data endpoint as `unknown` placeholders, so flagging by uploader cannot false-positive on legitimate topups observed by bar devices.
+
+- [ ] **Step 1: Add the uploading device to TransactionMerger**
+
+In `app/Tools/TransactionMerger.php`:
+
+Add import below the existing ones (line ~28):
+
+```php
+use App\Models\Device;
+```
+
+Replace the constructor:
+
+```php
+    /**
+     * @var Device|null
+     */
+    private $uploadingDevice;
+
+    public function __construct(Organisation $organisation, ?Device $uploadingDevice = null)
+    {
+        $this->organisation = $organisation;
+        $this->uploadingDevice = $uploadingDevice;
+    }
+```
+
+In `mergeTransaction()`, after `$transaction->mergeFromTransaction($entity);` and **before** the `if (!$transaction->exists && ...)` balance block, add:
+
+```php
+            if ($this->uploadingDevice) {
+                if (!$transaction->uploaded_by_device_id) {
+                    $transaction->uploaded_by_device_id = $this->uploadingDevice->id;
+                }
+
+                // Devices without topup permission cannot legitimately produce
+                // balance-adding transactions; keep them but mark for review.
+                if (
+                    !$this->uploadingDevice->allow_topup &&
+                    in_array($entity->transaction_type, [
+                        Transaction::TYPE_TOPUP,
+                        Transaction::TYPE_RESET,
+                        Transaction::TYPE_REFUND,
+                    ])
+                ) {
+                    $transaction->unauthorized = true;
+                }
+            }
+```
+
+- [ ] **Step 2: Pass the authenticated device from the controller**
+
+In `app/Http/DeviceApi/V1/Controllers/TransactionController.php`, `mergeTransactions()` (line ~73), replace:
+
+```php
+        $transactionMerger = new TransactionMerger($organisation);
+```
+
+with:
+
+```php
+        $uploadingDevice = $request->user() instanceof \App\Models\Device ? $request->user() : null;
+        $transactionMerger = new TransactionMerger($organisation, $uploadingDevice);
+```
+
+- [ ] **Step 3: Verify**
+
+```bash
+php artisan route:list --path=pos-api > /dev/null && echo OK
+grep -rn "new TransactionMerger" app/
+```
+Expected: `OK`; the grep shows only the Device API TransactionController instantiation (with the new argument).
+
+Logic check via tinker (uses first organisation + a fabricated device; skip if DB is empty):
+
+```bash
+php artisan tinker --execute="
+\$org = \App\Models\Organisation::first();
+\$device = new \App\Models\Device(['allow_topup' => false]);
+\$device->id = 999999;
+\$m = new \App\Tools\TransactionMerger(\$org, \$device);
+echo 'constructed ok';
+"
+```
+Expected: `constructed ok`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/Tools/TransactionMerger.php app/Http/DeviceApi/V1/Controllers/TransactionController.php
+git commit -m "Flag topup/reset/refund uploads from non-topup devices as unauthorized"
+```
+
+---
+
+### Task 5: Exclude sales-disabled devices from order assignment
+
+**Files:**
+- Modify: `app/Services/OrderAssignmentService.php:92-103` (reevaluate check), `app/Services/OrderAssignmentService.php:183-186` (findBestDevice query)
+
+**Interfaces:**
+- Consumes: `Device::$allow_sales` (Task 1).
+
+- [ ] **Step 1: Update `findBestDevice()`**
+
+In `app/Services/OrderAssignmentService.php` (line ~183), add the `allow_sales` condition to the online-devices query:
+
+```php
+		// Get all online devices for this organisation that accept remote orders
+		$onlineDevices = Device::where('organisation_id', $event->organisation_id)
+			->where('last_ping', '>', $cutoff)
+			->where('allow_remote_orders', true)
+			->where('allow_sales', true)
+			->get();
+```
+
+- [ ] **Step 2: Update `reevaluateAssignments()`**
+
+In the same file (line ~93), extend the changed-device check:
+
+```php
+					// If this order belongs to the device that just changed its settings,
+					// check if the device still accepts this order
+					if ($changedDevice && $device->id === $changedDevice->id) {
+						// Device disabled remote orders or sales — must reassign
+						if (!$device->allow_remote_orders || !$device->allow_sales) {
+							// Fall through to reassign
+						} else {
+```
+
+- [ ] **Step 3: Verify**
+
+```bash
+php artisan tinker --execute="new \App\Services\OrderAssignmentService(); echo 'ok';"
+```
+Expected: `ok`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/Services/OrderAssignmentService.php
+git commit -m "Exclude sales-disabled devices from remote order assignment"
+```
+
+---
+
+### Task 6: Manage UI — edit capabilities + list badges
+
+**Files:**
+- Modify: `resources/manage/js/views/Devices.vue` (edit modal ~line 185-198, fields array ~line 260-290, list cell templates ~line 47, `saveEdit()` ~line 375)
+- Modify: `resources/shared/js/i18n/en.js`, `nl.js`, `fr.js`, `de.js`, `es.js`
+
+**Interfaces:**
+- Consumes: Management API `allow_sales` / `allow_topup` (Task 3).
+
+- [ ] **Step 1: Add checkboxes to the edit-device modal**
+
+In `resources/manage/js/views/Devices.vue`, inside the edit modal (after the Device Name `b-form-group`, before `<template #modal-footer>`), add:
+
+```html
+		<b-form-group :description="$t('This device can process orders and sales.')">
+			<b-form-checkbox v-model="editModel.allow_sales">
+				{{ $t('Allow sales') }}
+			</b-form-checkbox>
+		</b-form-group>
+
+		<b-form-group :description="$t('This device can topup, reset and manage NFC cards.')">
+			<b-form-checkbox v-model="editModel.allow_topup">
+				{{ $t('Allow card topups') }}
+			</b-form-checkbox>
+		</b-form-group>
+```
+
+- [ ] **Step 2: Send the fields in `saveEdit()`**
+
+Replace the `saveEdit` method body:
+
+```js
+			async saveEdit() {
+				await this.service.update(this.editModel.id, {
+					name: this.editModel.name,
+					allow_sales: !!this.editModel.allow_sales,
+					allow_topup: !!this.editModel.allow_topup
+				});
+				this.resetEditForm();
+				this.refreshDevices();
+			},
+```
+
+- [ ] **Step 3: Add a capabilities column**
+
+In the `fields` array in `data()`, insert after the `status` entry:
+
+```js
+					{
+						key: 'capabilities',
+						label: this.$t('Capabilities'),
+					},
+```
+
+In the template, next to the other `cell(...)` slots (e.g. after the `cell(status)` template), add:
+
+```html
+					<template v-slot:cell(capabilities)="row">
+						<span v-if="row.item.allow_sales !== false" class="badge badge-info mr-1">{{ $t('Sales') }}</span>
+						<span v-if="row.item.allow_topup !== false" class="badge badge-success">{{ $t('Topup') }}</span>
+						<span v-if="row.item.allow_sales === false && row.item.allow_topup === false" class="badge badge-danger">{{ $t('Disabled') }}</span>
+					</template>
+```
+
+- [ ] **Step 4: Add i18n keys**
+
+Add to **all five** files `resources/shared/js/i18n/{en,nl,fr,de,es}.js`, in a new `// Device capabilities` section before the closing `}`:
+
+en.js:
+```js
+    // Device capabilities
+    'Allow sales': 'Allow sales',
+    'Allow card topups': 'Allow card topups',
+    'This device can process orders and sales.': 'This device can process orders and sales.',
+    'This device can topup, reset and manage NFC cards.': 'This device can topup, reset and manage NFC cards.',
+    'Capabilities': 'Capabilities',
+    'Sales': 'Sales',
+    'Disabled': 'Disabled',
+```
+
+nl.js:
+```js
+    // Device capabilities
+    'Allow sales': 'Verkoop toestaan',
+    'Allow card topups': 'Kaarten opwaarderen toestaan',
+    'This device can process orders and sales.': 'Dit apparaat kan bestellingen en verkopen verwerken.',
+    'This device can topup, reset and manage NFC cards.': 'Dit apparaat kan NFC-kaarten opwaarderen, resetten en beheren.',
+    'Capabilities': 'Functies',
+    'Sales': 'Verkoop',
+    'Disabled': 'Uitgeschakeld',
+```
+
+fr.js:
+```js
+    // Device capabilities
+    'Allow sales': 'Autoriser les ventes',
+    'Allow card topups': 'Autoriser le rechargement des cartes',
+    'This device can process orders and sales.': 'Cet appareil peut traiter les commandes et les ventes.',
+    'This device can topup, reset and manage NFC cards.': 'Cet appareil peut recharger, réinitialiser et gérer les cartes NFC.',
+    'Capabilities': 'Fonctions',
+    'Sales': 'Ventes',
+    'Disabled': 'Désactivé',
+```
+
+de.js:
+```js
+    // Device capabilities
+    'Allow sales': 'Verkäufe erlauben',
+    'Allow card topups': 'Kartenaufladung erlauben',
+    'This device can process orders and sales.': 'Dieses Gerät kann Bestellungen und Verkäufe verarbeiten.',
+    'This device can topup, reset and manage NFC cards.': 'Dieses Gerät kann NFC-Karten aufladen, zurücksetzen und verwalten.',
+    'Capabilities': 'Funktionen',
+    'Sales': 'Verkauf',
+    'Disabled': 'Deaktiviert',
+```
+
+es.js:
+```js
+    // Device capabilities
+    'Allow sales': 'Permitir ventas',
+    'Allow card topups': 'Permitir recargas de tarjetas',
+    'This device can process orders and sales.': 'Este dispositivo puede procesar pedidos y ventas.',
+    'This device can topup, reset and manage NFC cards.': 'Este dispositivo puede recargar, restablecer y gestionar tarjetas NFC.',
+    'Capabilities': 'Capacidades',
+    'Sales': 'Ventas',
+    'Disabled': 'Desactivado',
+```
+
+Note: `'Topup'` already exists in all five files — do not add it again.
+
+- [ ] **Step 5: Run JS tests and build**
+
+```bash
+npx vitest run
+npm run dev
+```
+Expected: vitest passes; build succeeds.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git checkout -- package-lock.json 2>/dev/null || true
+git add resources/manage/js/views/Devices.vue resources/shared/js/i18n/
+git commit -m "Manage UI: edit device capability flags, show capability badges"
+```
+
+---
+
+### Task 7: POS capability guard (TDD) + boot wiring + disabled screen
+
+**Files:**
+- Create: `resources/pos/js/deviceCapabilities.js`
+- Create: `resources/pos/js/views/Disabled.vue`
+- Test: `resources/tests/device-capabilities.test.js`
+- Modify: `resources/pos/js/app.js` (imports ~line 1-90, routes ~line 119-208, guard after router creation ~line 209, boot flags ~line 239-245)
+- Modify: `resources/shared/js/i18n/{en,nl,fr,de,es}.js`
+
+**Interfaces:**
+- Consumes: `allow_sales` / `allow_topup` on the `devices/current` response (Task 3).
+- Produces:
+  - `getDeviceCapabilities(): { allowSales: boolean, allowTopup: boolean }` (reads `window.DEVICE_ALLOW_SALES` / `window.DEVICE_ALLOW_TOPUP`, missing ⇒ `true`)
+  - `resolveCapabilityRedirect(routeName: string|null, capabilities): string|null` — returns a route **name** to redirect to, or `null` to allow. Task 8 reads the same window flags.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `resources/tests/device-capabilities.test.js`:
+
+```js
+/**
+ * Tests for POS device capability gating (allow_sales / allow_topup).
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import { getDeviceCapabilities, resolveCapabilityRedirect } from '../pos/js/deviceCapabilities';
+
+const BOTH = { allowSales: true, allowTopup: true };
+const SALES_ONLY = { allowSales: true, allowTopup: false };
+const TOPUP_ONLY = { allowSales: false, allowTopup: true };
+const NONE = { allowSales: false, allowTopup: false };
+
+describe('resolveCapabilityRedirect', () => {
+
+	it('allows everything when both capabilities are enabled', () => {
+		['home', 'events', 'hq', 'cards', 'transactions', 'settings'].forEach((name) => {
+			expect(resolveCapabilityRedirect(name, BOTH)).toBeNull();
+		});
+	});
+
+	it('redirects card routes to events on sales-only devices', () => {
+		expect(resolveCapabilityRedirect('cards', SALES_ONLY)).toBe('events');
+		expect(resolveCapabilityRedirect('transactions', SALES_ONLY)).toBe('events');
+		expect(resolveCapabilityRedirect('testTransactions', SALES_ONLY)).toBe('events');
+	});
+
+	it('keeps sales routes accessible on sales-only devices', () => {
+		expect(resolveCapabilityRedirect('events', SALES_ONLY)).toBeNull();
+		expect(resolveCapabilityRedirect('hq', SALES_ONLY)).toBeNull();
+	});
+
+	it('redirects sales routes to cards on topup-only devices', () => {
+		['home', 'events', 'menu', 'hq', 'sales', 'summary', 'summary-names', 'attendees', 'checkIn'].forEach((name) => {
+			expect(resolveCapabilityRedirect(name, TOPUP_ONLY)).toBe('cards');
+		});
+	});
+
+	it('keeps card routes accessible on topup-only devices', () => {
+		expect(resolveCapabilityRedirect('cards', TOPUP_ONLY)).toBeNull();
+		expect(resolveCapabilityRedirect('transactions', TOPUP_ONLY)).toBeNull();
+	});
+
+	it('redirects everything gated to the disabled screen when nothing is allowed', () => {
+		expect(resolveCapabilityRedirect('events', NONE)).toBe('disabled');
+		expect(resolveCapabilityRedirect('cards', NONE)).toBe('disabled');
+	});
+
+	it('always allows settings and the disabled screen itself', () => {
+		expect(resolveCapabilityRedirect('settings', NONE)).toBeNull();
+		expect(resolveCapabilityRedirect('disabled', NONE)).toBeNull();
+	});
+
+	it('bounces away from the disabled screen when capabilities exist', () => {
+		expect(resolveCapabilityRedirect('disabled', BOTH)).toBe('events');
+		expect(resolveCapabilityRedirect('disabled', TOPUP_ONLY)).toBe('cards');
+		expect(resolveCapabilityRedirect('disabled', SALES_ONLY)).toBe('events');
+	});
+});
+
+describe('getDeviceCapabilities', () => {
+
+	afterEach(() => {
+		delete globalThis.window;
+	});
+
+	it('defaults to fully enabled when flags are missing', () => {
+		globalThis.window = {};
+		expect(getDeviceCapabilities()).toEqual({ allowSales: true, allowTopup: true });
+	});
+
+	it('reads explicit false flags', () => {
+		globalThis.window = { DEVICE_ALLOW_SALES: false, DEVICE_ALLOW_TOPUP: false };
+		expect(getDeviceCapabilities()).toEqual({ allowSales: false, allowTopup: false });
+	});
+});
+
+describe('POS app wiring', () => {
+	const source = readFileSync(resolve(__dirname, '..', 'pos', 'js', 'app.js'), 'utf-8');
+
+	it('sets window capability flags from device data', () => {
+		expect(source).toContain('window.DEVICE_ALLOW_SALES');
+		expect(source).toContain('window.DEVICE_ALLOW_TOPUP');
+	});
+
+	it('registers the capability guard', () => {
+		expect(source).toContain('resolveCapabilityRedirect');
+		expect(source).toContain('router.beforeEach');
+	});
+
+	it('has the disabled route', () => {
+		expect(source).toContain("name: 'disabled'");
+	});
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+npx vitest run resources/tests/device-capabilities.test.js
+```
+Expected: FAIL — cannot resolve `../pos/js/deviceCapabilities`.
+
+- [ ] **Step 3: Implement the capability module**
+
+Create `resources/pos/js/deviceCapabilities.js`:
+
+```js
+/*
+ * Device capability gating for the POS app.
+ *
+ * allow_sales / allow_topup are admin-controlled flags loaded from
+ * GET /pos-api/v1/devices/current at boot. Missing flags (old cached
+ * responses) are treated as enabled so existing devices keep working.
+ */
+
+// Route names that require the sales capability.
+const SALES_ROUTES = [
+	'home',
+	'events',
+	'menu',
+	'hq',
+	'sales',
+	'summary',
+	'summary-names',
+	'attendees',
+	'checkIn',
+];
+
+// Route names that require the topup capability.
+const TOPUP_ROUTES = [
+	'cards',
+	'transactions',
+	'testTransactions',
+];
+
+export function getDeviceCapabilities() {
+	return {
+		allowSales: window.DEVICE_ALLOW_SALES !== false,
+		allowTopup: window.DEVICE_ALLOW_TOPUP !== false,
+	};
+}
+
+/**
+ * Decide whether navigation to a route is allowed.
+ * Returns the route name to redirect to, or null when allowed.
+ */
+export function resolveCapabilityRedirect(routeName, capabilities) {
+	const { allowSales, allowTopup } = capabilities;
+
+	if (!allowSales && SALES_ROUTES.indexOf(routeName) !== -1) {
+		return allowTopup ? 'cards' : 'disabled';
+	}
+
+	if (!allowTopup && TOPUP_ROUTES.indexOf(routeName) !== -1) {
+		return allowSales ? 'events' : 'disabled';
+	}
+
+	if (routeName === 'disabled' && (allowSales || allowTopup)) {
+		// Device regained a capability; leave the dead-end screen.
+		return allowSales ? 'events' : 'cards';
+	}
+
+	return null;
+}
+```
+
+- [ ] **Step 4: Create the disabled screen**
+
+Create `resources/pos/js/views/Disabled.vue`:
+
+```html
+<!--
+  - CatLab Drinks - Simple bar automation system
+  - Copyright (C) 2019 Thijs Van der Schaeghe
+  - CatLab Interactive bvba, Gent, Belgium
+  - http://www.catlab.eu/
+  -
+  - This program is free software; you can redistribute it and/or modify
+  - it under the terms of the GNU General Public License as published by
+  - the Free Software Foundation; either version 3 of the License, or
+  - (at your option) any later version.
+  -
+  - This program is distributed in the hope that it will be useful,
+  - but WITHOUT ANY WARRANTY; without even the implied warranty of
+  - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  - GNU General Public License for more details.
+  -
+  - You should have received a copy of the GNU General Public License along
+  - with this program; if not, write to the Free Software Foundation, Inc.,
+  - 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+  -->
+
+<template>
+	<b-container fluid>
+		<b-alert variant="warning" :show="true" class="mt-3 text-center">
+			<p class="mb-1"><strong>{{ $t('This device has no functions enabled.') }}</strong></p>
+			<p class="mb-0">{{ $t('Please contact your administrator to enable sales or topups for this device.') }}</p>
+		</b-alert>
+	</b-container>
+</template>
+
+<script>
+	export default {};
+</script>
+```
+
+- [ ] **Step 5: Wire into `resources/pos/js/app.js`**
+
+Add imports near the other view imports at the top of the file:
+
+```js
+import Disabled from './views/Disabled.vue';
+import { getDeviceCapabilities, resolveCapabilityRedirect } from './deviceCapabilities';
+```
+
+Add the route to the `routes` array (after the `financialOverview` entry):
+
+```js
+			{
+				path: '/disabled',
+				name: 'disabled',
+				component: Disabled
+			}
+```
+
+Immediately after `const router = createRouter({...});`, register the guard:
+
+```js
+	router.beforeEach((to, from, next) => {
+		const redirect = resolveCapabilityRedirect(to.name, getDeviceCapabilities());
+		if (redirect) {
+			next({ name: redirect });
+		} else {
+			next();
+		}
+	});
+```
+
+In the boot block where `window.DEVICE_NAME` etc. are set (after `window.DEVICE_PUBLIC_KEY = ...`), add:
+
+```js
+				window.DEVICE_ALLOW_SALES = deviceData.allow_sales !== false;
+				window.DEVICE_ALLOW_TOPUP = deviceData.allow_topup !== false;
+```
+
+(This runs before `app.mount('#app')`, so the guard always sees resolved flags.)
+
+- [ ] **Step 6: Add i18n keys**
+
+Add to the `// Device capabilities` section (created in Task 6; create it if executing out of order) of all five locale files:
+
+en.js:
+```js
+    'This device has no functions enabled.': 'This device has no functions enabled.',
+    'Please contact your administrator to enable sales or topups for this device.': 'Please contact your administrator to enable sales or topups for this device.',
+```
+
+nl.js:
+```js
+    'This device has no functions enabled.': 'Dit apparaat heeft geen functies ingeschakeld.',
+    'Please contact your administrator to enable sales or topups for this device.': 'Neem contact op met je beheerder om verkoop of opwaarderen voor dit apparaat in te schakelen.',
+```
+
+fr.js:
+```js
+    'This device has no functions enabled.': 'Cet appareil n\'a aucune fonction activée.',
+    'Please contact your administrator to enable sales or topups for this device.': 'Veuillez contacter votre administrateur pour activer les ventes ou les rechargements pour cet appareil.',
+```
+
+de.js:
+```js
+    'This device has no functions enabled.': 'Für dieses Gerät sind keine Funktionen aktiviert.',
+    'Please contact your administrator to enable sales or topups for this device.': 'Bitte kontaktiere deinen Administrator, um Verkäufe oder Aufladungen für dieses Gerät zu aktivieren.',
+```
+
+es.js:
+```js
+    'This device has no functions enabled.': 'Este dispositivo no tiene funciones habilitadas.',
+    'Please contact your administrator to enable sales or topups for this device.': 'Ponte en contacto con tu administrador para habilitar ventas o recargas en este dispositivo.',
+```
+
+- [ ] **Step 7: Run tests to verify they pass**
+
+```bash
+npx vitest run
+```
+Expected: all tests PASS, including `device-capabilities.test.js`.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git checkout -- package-lock.json 2>/dev/null || true
+git add resources/pos/js/deviceCapabilities.js resources/pos/js/views/Disabled.vue resources/pos/js/app.js resources/tests/device-capabilities.test.js resources/shared/js/i18n/
+git commit -m "POS: gate routes by device capability flags"
+```
+
+---
+
+### Task 8: POS nav + settings gating
+
+**Files:**
+- Modify: `resources/pos/js/views/App.vue` (nav ~line 44-56, data ~line 190-200)
+- Modify: `resources/pos/js/views/Settings.vue` (order toggles ~line 55-73, data ~line 264-286)
+
+**Interfaces:**
+- Consumes: `window.DEVICE_ALLOW_SALES` / `window.DEVICE_ALLOW_TOPUP` (set in Task 7 before the app mounts).
+
+- [ ] **Step 1: Gate the navbar items in `App.vue`**
+
+In `resources/pos/js/views/App.vue`, change the two nav items:
+
+```html
+					<b-nav-item :to="{ name: 'events' }"  v-if="!kioskMode && allowSales">{{ $t('Events') }}</b-nav-item>
+```
+
+```html
+						<b-nav-item :to="{ name: 'cards' }" v-if="allowTopup">{{ $t('Cards') }}</b-nav-item>
+```
+
+In the component's `data()` (where `kioskMode: false` is defined, ~line 197), add:
+
+```js
+				allowSales: window.DEVICE_ALLOW_SALES !== false,
+				allowTopup: window.DEVICE_ALLOW_TOPUP !== false,
+```
+
+- [ ] **Step 2: Hide the order toggles on sales-disabled devices in `Settings.vue`**
+
+In `resources/pos/js/views/Settings.vue`, wrap the two order checkboxes (the `allow_live_orders` and `allow_remote_orders` `b-form-group` blocks) in a template guard:
+
+```html
+						<template v-if="allowSales">
+							<b-form-group
+								id="allow_live_orders"
+								:description="$t('This terminal can process orders at the bar')"
+							>
+								<label>
+									<input type="checkbox" v-model="allowLiveOrders"></input>
+									{{ $t('Allow live orders at this terminal') }}<br />
+								</label>
+							</b-form-group>
+
+							<b-form-group
+								id="allow_remote_orders"
+								:description="$t('This terminal can process orders from tables')"
+							>
+								<label>
+									<input type="checkbox" v-model="allowRemoteOrders"></input>
+									{{ $t('Allow remote orders at this terminal') }}<br />
+								</label>
+							</b-form-group>
+						</template>
+```
+
+In `data()`, add:
+
+```js
+					allowSales: window.DEVICE_ALLOW_SALES !== false,
+```
+
+- [ ] **Step 3: Run tests and build**
+
+```bash
+npx vitest run
+npm run dev
+```
+Expected: tests pass, build succeeds.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git checkout -- package-lock.json 2>/dev/null || true
+git add resources/pos/js/views/App.vue resources/pos/js/views/Settings.vue
+git commit -m "POS: hide sales/topup UI according to device capabilities"
+```
+
+---
+
+### Task 9: Unauthorized badge in transaction overviews
+
+**Files:**
+- Modify: `resources/shared/js/nfccards/models/Transaction.ts` (~line 28)
+- Modify: `resources/shared/js/nfccards/store/TransactionStore.ts:341-378` (`mapTransactions`)
+- Modify: `resources/shared/js/components/TransactionsTable.vue:37-42`
+- Modify: `resources/shared/js/i18n/{en,nl,fr,de,es}.js`
+
+**Interfaces:**
+- Consumes: `unauthorized` field on transaction API resources (Task 3; included automatically because the store requests `fields=*`).
+- Produces: `Transaction.unauthorized: boolean` on the client model.
+
+- [ ] **Step 1: Add the property to the client Transaction model**
+
+In `resources/shared/js/nfccards/models/Transaction.ts`, after `public uploaded = false;`:
+
+```ts
+    public unauthorized = false;
+```
+
+- [ ] **Step 2: Map the API field**
+
+In `resources/shared/js/nfccards/store/TransactionStore.ts`, in `mapTransactions()`, after `transaction.uploaded = true;`:
+
+```ts
+                transaction.unauthorized = !!item.unauthorized;
+```
+
+- [ ] **Step 3: Show the badge in the transactions table**
+
+In `resources/shared/js/components/TransactionsTable.vue`, replace the `cell(order)` template:
+
+```html
+            <template v-slot:cell(order)="row">
+                <span v-if="row.item.order">
+                    <a href="javascript:void(0)" class="btn btn-sm btn-info" v-on:click="showOrder(row.item.order)">Order #{{row.item.order.id}}</a>
+                </span>
+                <span v-else>{{ row.item.type }}</span>
+                <span v-if="row.item.unauthorized" class="badge badge-danger ml-1" :title="$t('This transaction was uploaded by a device that is not allowed to topup cards.')">{{ $t('Unauthorized') }}</span>
+            </template>
+```
+
+- [ ] **Step 4: Add i18n keys**
+
+Add to the `// Device capabilities` section of all five locale files:
+
+en.js:
+```js
+    'Unauthorized': 'Unauthorized',
+    'This transaction was uploaded by a device that is not allowed to topup cards.': 'This transaction was uploaded by a device that is not allowed to topup cards.',
+```
+
+nl.js:
+```js
+    'Unauthorized': 'Niet toegestaan',
+    'This transaction was uploaded by a device that is not allowed to topup cards.': 'Deze transactie werd geüpload door een apparaat dat geen kaarten mag opwaarderen.',
+```
+
+fr.js:
+```js
+    'Unauthorized': 'Non autorisé',
+    'This transaction was uploaded by a device that is not allowed to topup cards.': 'Cette transaction a été envoyée par un appareil qui n\'est pas autorisé à recharger les cartes.',
+```
+
+de.js:
+```js
+    'Unauthorized': 'Nicht autorisiert',
+    'This transaction was uploaded by a device that is not allowed to topup cards.': 'Diese Transaktion wurde von einem Gerät hochgeladen, das keine Karten aufladen darf.',
+```
+
+es.js:
+```js
+    'Unauthorized': 'No autorizado',
+    'This transaction was uploaded by a device that is not allowed to topup cards.': 'Esta transacción fue subida por un dispositivo que no puede recargar tarjetas.',
+```
+
+- [ ] **Step 5: Run tests**
+
+```bash
+npx vitest run
+npx jest
+```
+Expected: all pass (jest covers the NFC model code we touched).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git checkout -- package-lock.json 2>/dev/null || true
+git add resources/shared/js/nfccards/models/Transaction.ts resources/shared/js/nfccards/store/TransactionStore.ts resources/shared/js/components/TransactionsTable.vue resources/shared/js/i18n/
+git commit -m "Show unauthorized badge on flagged transactions"
+```
+
+---
+
+### Task 10: Final verification & production build
+
+**Files:** none new — verification only.
+
+- [ ] **Step 1: Full JS test suites**
+
+```bash
+npx vitest run
+npx jest
+```
+Expected: all pass.
+
+- [ ] **Step 2: Production build**
+
+```bash
+npm run production
+git checkout -- package-lock.json 2>/dev/null || true
+git status
+```
+Expected: build succeeds; only `public/res/` build artifacts changed (check whether this repo commits build output — if `git status` shows `public/res/` untracked/ignored, leave it; do NOT commit `package-lock.json`).
+
+- [ ] **Step 3: Backend smoke checks**
+
+```bash
+php artisan migrate:status | tail -5
+php artisan route:list --path=pos-api > /dev/null && echo POS-API-OK
+php artisan route:list --path=api/v1 > /dev/null && echo MGMT-API-OK
+```
+Expected: both new migrations `Ran`; `POS-API-OK`, `MGMT-API-OK`.
+
+- [ ] **Step 4: Manual end-to-end checklist (requires running app + paired device; report what was and wasn't checked)**
+
+1. Manage → Devices → Edit: uncheck "Allow card topups" on a device, save. Reload list → device shows only "Sales" badge.
+2. On that POS device (reload): "Cards" nav item gone; navigating to `/cards` directly redirects to events.
+3. `PUT /pos-api/v1/devices/current` with `{"allow_topup": true}` using the device token → response still shows `allow_topup: false` (read-only field ignored).
+4. Uncheck "Allow sales" too → POS lands on the disabled screen; Settings still reachable.
+5. Re-enable both → POS back to normal.
+6. (If NFC hardware available) With `allow_topup` off, force a topup via the API/an unpatched client → transaction appears with "Unauthorized" badge in Manage → Transactions.
+
+- [ ] **Step 5: Final commit (if verification produced changes)**
+
+```bash
+git status
+```
+If clean apart from ignored build output: done. Otherwise commit fixes with a descriptive message.

--- a/docs/superpowers/plans/2026-07-08-device-capability-flags.md
+++ b/docs/superpowers/plans/2026-07-08-device-capability-flags.md
@@ -14,7 +14,7 @@
 
 - Never run `npm update`; use `npm install` only. Never commit `package-lock.json` changes — run `git checkout -- package-lock.json` before committing.
 - PHP deps: lock file requires PHP ~8.1/~8.2; use `composer install --ignore-platform-reqs` if needed (vendor/ is already installed).
-- No PHP test suite exists — backend tasks are verified manually via `php artisan migrate`, `php artisan route:list`, and `php artisan tinker`. The local MySQL comes from `docker-compose.yml`; run `docker compose up -d` if the DB is not running.
+- A PHPUnit feature-test suite exists in `tests/Feature/` (CLAUDE.md's "no test suite" note is outdated). Run it with the dockerized runner that mirrors CI: `docker compose run --rm phpunit` (add `--filter SomeTest` to scope). It must be green before every backend commit. Tests use tabs, `RefreshDatabase`, and model factories from `database/factories/`.
 - JS tests: `npx vitest run` (route/view tests), `npx jest` (NFC tests). Both must pass before every commit that touches JS.
 - All user-facing strings go through `$t('...')` and must be added to **all five** locale files: `resources/shared/js/i18n/{en,nl,fr,de,es}.js` (identical key sets; keys are the English strings).
 - Tabs for indentation in PHP and Vue files (match existing files).
@@ -114,25 +114,41 @@ In the `static::updated` hook (currently around line 78), extend the reassignmen
 				|| ($device->wasChanged('allow_sales') && !$device->allow_sales);
 ```
 
-- [ ] **Step 3: Run the migration and verify**
+- [ ] **Step 3: Write the failing test**
 
-```bash
-docker compose up -d   # only if DB not already running
-php artisan migrate
+Add to `tests/Feature/DeviceControllerTest.php` (after `testCurrentDeviceReturnsDeviceInfo`):
+
+```php
+	public function testCapabilityFlagsDefaultToEnabled(): void
+	{
+		$device = Device::factory()->create([
+			'organisation_id' => $this->organisation->id,
+		]);
+
+		$device->refresh();
+		$this->assertTrue($device->allow_sales);
+		$this->assertTrue($device->allow_topup);
+	}
 ```
-Expected: `2026_07_08_100000_add_capability_flags_to_devices ... DONE`
 
-Verify defaults with tinker:
+Run **before** applying Steps 1–2 (or stash them) to see it fail, or simply run after writing only the test:
 
 ```bash
-php artisan tinker --execute="var_dump(\App\Models\Device::query()->first()?->allow_sales, \App\Models\Device::query()->first()?->allow_topup);"
+docker compose run --rm phpunit --filter testCapabilityFlagsDefaultToEnabled
 ```
-Expected: `bool(true)` twice (or `NULL NULL` if the table is empty — then just check the columns exist: `php artisan tinker --execute="var_dump(\Illuminate\Support\Facades\Schema::hasColumns('devices', ['allow_sales','allow_topup']));"` → `bool(true)`).
+Expected: FAIL (unknown column / null attribute) without the migration; PASS once Steps 1–2 are in place.
 
-- [ ] **Step 4: Commit**
+- [ ] **Step 4: Run the full suite**
 
 ```bash
-git add database/migrations/2026_07_08_100000_add_capability_flags_to_devices.php app/Models/Device.php
+docker compose run --rm phpunit
+```
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add database/migrations/2026_07_08_100000_add_capability_flags_to_devices.php app/Models/Device.php tests/Feature/DeviceControllerTest.php
 git commit -m "Add allow_sales/allow_topup capability flags to devices"
 ```
 
@@ -213,13 +229,12 @@ In `app/Models/Transaction.php`, add a `$casts` property (the model currently ha
 
 Add `use App\Models\Device;` only if the model isn't already in the same namespace — it is (`App\Models`), so no import is needed.
 
-- [ ] **Step 3: Run the migration and verify**
+- [ ] **Step 3: Run the suite (migration is exercised by RefreshDatabase)**
 
 ```bash
-php artisan migrate
-php artisan tinker --execute="var_dump(\Illuminate\Support\Facades\Schema::hasColumns('card_transactions', ['uploaded_by_device_id','unauthorized']));"
+docker compose run --rm phpunit
 ```
-Expected: `bool(true)`
+Expected: all tests pass (Task 4 adds the behavioral tests for these columns; this task only needs the schema to migrate cleanly).
 
 - [ ] **Step 4: Commit**
 
@@ -285,18 +300,81 @@ In `app/Http/DeviceApi/V1/ResourceDefinitions/TransactionResourceDefinition.php`
             ->visible(true);
 ```
 
-- [ ] **Step 4: Verify routes still register**
+- [ ] **Step 4: Write the tests (write first, watch them fail, then apply Steps 1–3)**
 
-```bash
-php artisan route:list --path=pos-api | head -30
-php artisan route:list --path=api/v1/devices
+Add to `tests/Feature/DeviceControllerTest.php` (uses the class's existing `$this->device`, `$this->token`, `$this->user`; `Laravel\Passport\Passport` is already imported):
+
+```php
+	public function testCurrentDeviceExposesCapabilityFlags(): void
+	{
+		$this->device->allow_topup = false;
+		$this->device->save();
+
+		$response = $this
+			->withHeader('Authorization', 'Bearer ' . $this->token->access_token)
+			->getJson('/pos-api/v1/devices/current');
+
+		$response->assertStatus(200);
+		$response->assertJsonFragment([
+			'allow_sales' => true,
+			'allow_topup' => false,
+		]);
+	}
+
+	public function testUpdateCurrentDeviceCannotChangeCapabilityFlags(): void
+	{
+		$this->device->allow_topup = false;
+		$this->device->save();
+
+		$response = $this
+			->withHeader('Authorization', 'Bearer ' . $this->token->access_token)
+			->putJson('/pos-api/v1/devices/current', [
+				'allow_topup' => true,
+				'allow_sales' => false,
+			]);
+
+		$response->assertStatus(200);
+
+		$this->device->refresh();
+		// Device API must ignore these fields entirely.
+		$this->assertFalse($this->device->allow_topup);
+		$this->assertTrue($this->device->allow_sales);
+	}
+
+	public function testManagementApiCanUpdateCapabilityFlags(): void
+	{
+		Passport::actingAs($this->user);
+
+		$response = $this->putJson('/api/v1/devices/' . $this->device->id, [
+			'name' => $this->device->name,
+			'allow_sales' => false,
+			'allow_topup' => false,
+		]);
+
+		$response->assertStatus(200);
+
+		$this->device->refresh();
+		$this->assertFalse($this->device->allow_sales);
+		$this->assertFalse($this->device->allow_topup);
+	}
 ```
-Expected: routes list without errors (a Charon definition typo throws during route registration).
-
-- [ ] **Step 5: Commit**
 
 ```bash
-git add app/Http/ManagementApi/V1/ResourceDefinitions/DeviceResourceDefinition.php app/Http/DeviceApi/V1/ResourceDefinitions/DeviceResourceDefinition.php app/Http/DeviceApi/V1/ResourceDefinitions/TransactionResourceDefinition.php
+docker compose run --rm phpunit --filter DeviceControllerTest
+```
+Expected: the three new tests FAIL before Steps 1–3 are applied (missing JSON fields / flags not updated), PASS after.
+
+- [ ] **Step 5: Run the full suite**
+
+```bash
+docker compose run --rm phpunit
+```
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/Http/ManagementApi/V1/ResourceDefinitions/DeviceResourceDefinition.php app/Http/DeviceApi/V1/ResourceDefinitions/DeviceResourceDefinition.php app/Http/DeviceApi/V1/ResourceDefinitions/TransactionResourceDefinition.php tests/Feature/DeviceControllerTest.php
 git commit -m "Expose capability flags via APIs (admin-writeable, device read-only)"
 ```
 
@@ -377,31 +455,134 @@ with:
         $transactionMerger = new TransactionMerger($organisation, $uploadingDevice);
 ```
 
-- [ ] **Step 3: Verify**
+- [ ] **Step 3: Write the tests (TDD — write first, watch them fail, then apply Steps 1–2)**
 
-```bash
-php artisan route:list --path=pos-api > /dev/null && echo OK
-grep -rn "new TransactionMerger" app/
+Add to `tests/Feature/TransactionMergerTest.php` (uses the class's existing `$this->organisation`, `$this->user`, `createCard()`, `makeTransaction()` helpers — `makeTransaction(cardUid, syncId, value, type)`):
+
+```php
+	public function testMergeRecordsUploadingDevice(): void
+	{
+		$device = Device::factory()->create([
+			'organisation_id' => $this->organisation->id,
+		]);
+		$card = $this->createCard();
+
+		$merger = new TransactionMerger($this->organisation, $device);
+		$merger->mergeTransactions([
+			$this->makeTransaction($card->uid, 1, 500, 'topup'),
+		]);
+
+		$stored = Transaction::where('card_id', $card->id)->where('card_sync_id', 1)->first();
+		$this->assertEquals($device->id, $stored->uploaded_by_device_id);
+		$this->assertFalse($stored->unauthorized);
+	}
+
+	public function testTopupFromNonTopupDeviceIsFlagged(): void
+	{
+		$device = Device::factory()->create([
+			'organisation_id' => $this->organisation->id,
+			'allow_topup' => false,
+		]);
+		$card = $this->createCard();
+
+		$merger = new TransactionMerger($this->organisation, $device);
+		$merger->mergeTransactions([
+			$this->makeTransaction($card->uid, 1, 500, 'topup'),
+			$this->makeTransaction($card->uid, 2, -200, 'sale'),
+		]);
+
+		$topup = Transaction::where('card_id', $card->id)->where('card_sync_id', 1)->first();
+		$sale = Transaction::where('card_id', $card->id)->where('card_sync_id', 2)->first();
+		$this->assertTrue($topup->unauthorized);
+		$this->assertFalse($sale->unauthorized);
+	}
+
+	public function testResetAndRefundFromNonTopupDeviceAreFlagged(): void
+	{
+		$device = Device::factory()->create([
+			'organisation_id' => $this->organisation->id,
+			'allow_topup' => false,
+		]);
+		$card = $this->createCard();
+
+		$merger = new TransactionMerger($this->organisation, $device);
+		$merger->mergeTransactions([
+			$this->makeTransaction($card->uid, 1, 500, 'reset'),
+			$this->makeTransaction($card->uid, 2, -100, 'refund'),
+		]);
+
+		$this->assertTrue(Transaction::where('card_id', $card->id)->where('card_sync_id', 1)->first()->unauthorized);
+		$this->assertTrue(Transaction::where('card_id', $card->id)->where('card_sync_id', 2)->first()->unauthorized);
+	}
+
+	public function testMergeWithoutDeviceDoesNotFlag(): void
+	{
+		$card = $this->createCard();
+
+		$merger = new TransactionMerger($this->organisation);
+		$merger->mergeTransactions([
+			$this->makeTransaction($card->uid, 1, 500, 'topup'),
+		]);
+
+		$stored = Transaction::where('card_id', $card->id)->where('card_sync_id', 1)->first();
+		$this->assertNull($stored->uploaded_by_device_id);
+		$this->assertFalse($stored->unauthorized);
+	}
+
+	public function testMergeEndpointFlagsUnauthorizedTopup(): void
+	{
+		$device = Device::factory()->create([
+			'organisation_id' => $this->organisation->id,
+			'allow_topup' => false,
+		]);
+		$card = $this->createCard('card-unauth-001');
+
+		$token = new DeviceAccessToken([
+			'device_id' => $device->id,
+			'access_token' => 'unauth-test-token',
+			'expires_at' => now()->addHour(),
+		]);
+		$token->created_by = $this->user->id;
+		$token->save();
+
+		$response = $this
+			->withHeader('Authorization', 'Bearer ' . $token->access_token)
+			->postJson('/pos-api/v1/organisations/' . $this->organisation->id . '/merge-transactions', [
+				'items' => [
+					[
+						'card' => 'card-unauth-001',
+						'card_transaction' => 1,
+						'value' => 500,
+						'type' => 'topup',
+						'has_synced' => true,
+					],
+				],
+			]);
+
+		$response->assertStatus(200);
+
+		$stored = Transaction::where('card_id', $card->id)->where('card_sync_id', 1)->first();
+		$this->assertTrue($stored->unauthorized);
+		$this->assertEquals($device->id, $stored->uploaded_by_device_id);
+	}
 ```
-Expected: `OK`; the grep shows only the Device API TransactionController instantiation (with the new argument).
-
-Logic check via tinker (uses first organisation + a fabricated device; skip if DB is empty):
 
 ```bash
-php artisan tinker --execute="
-\$org = \App\Models\Organisation::first();
-\$device = new \App\Models\Device(['allow_topup' => false]);
-\$device->id = 999999;
-\$m = new \App\Tools\TransactionMerger(\$org, \$device);
-echo 'constructed ok';
-"
+docker compose run --rm phpunit --filter TransactionMergerTest
 ```
-Expected: `constructed ok`
+Expected: new tests FAIL before Steps 1–2 (constructor accepts one arg / flags never set), PASS after.
 
-- [ ] **Step 4: Commit**
+- [ ] **Step 4: Run the full suite**
 
 ```bash
-git add app/Tools/TransactionMerger.php app/Http/DeviceApi/V1/Controllers/TransactionController.php
+docker compose run --rm phpunit
+```
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/Tools/TransactionMerger.php app/Http/DeviceApi/V1/Controllers/TransactionController.php tests/Feature/TransactionMergerTest.php
 git commit -m "Flag topup/reset/refund uploads from non-topup devices as unauthorized"
 ```
 
@@ -442,17 +623,56 @@ In the same file (line ~93), extend the changed-device check:
 						} else {
 ```
 
-- [ ] **Step 3: Verify**
+- [ ] **Step 3: Write the tests (TDD — write first, watch them fail, then apply Steps 1–2)**
 
-```bash
-php artisan tinker --execute="new \App\Services\OrderAssignmentService(); echo 'ok';"
+Add to `tests/Feature/OrderAssignmentServiceTest.php` (uses the class's existing `createDevice()` and `createOrder()` helpers; devices from the factory are online by default):
+
+```php
+	public function testAssignOrderExcludesSalesDisabledDevices(): void
+	{
+		$this->createDevice(['name' => 'Topup station', 'allow_sales' => false]);
+		$salesDevice = $this->createDevice(['name' => 'Bar POS']);
+
+		$order = $this->createOrder();
+		$this->service->assignOrder($order);
+
+		$order->refresh();
+		$this->assertEquals($salesDevice->id, $order->assigned_device_id);
+	}
+
+	public function testReevaluateReassignsWhenSalesDisabled(): void
+	{
+		$device1 = $this->createDevice([
+			'name' => 'POS 1',
+			'allow_sales' => false, // just disabled by admin
+		]);
+		$device2 = $this->createDevice(['name' => 'POS 2']);
+
+		$order = $this->createOrder(['assigned_device_id' => $device1->id]);
+
+		$this->service->reevaluateAssignments($this->event, $device1);
+
+		$order->refresh();
+		$this->assertEquals($device2->id, $order->assigned_device_id);
+	}
 ```
-Expected: `ok`
-
-- [ ] **Step 4: Commit**
 
 ```bash
-git add app/Services/OrderAssignmentService.php
+docker compose run --rm phpunit --filter OrderAssignmentServiceTest
+```
+Expected: the two new tests FAIL before Steps 1–2, PASS after.
+
+- [ ] **Step 4: Run the full suite**
+
+```bash
+docker compose run --rm phpunit
+```
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/Services/OrderAssignmentService.php tests/Feature/OrderAssignmentServiceTest.php
 git commit -m "Exclude sales-disabled devices from remote order assignment"
 ```
 
@@ -1120,14 +1340,14 @@ git status
 ```
 Expected: build succeeds; only `public/res/` build artifacts changed (check whether this repo commits build output — if `git status` shows `public/res/` untracked/ignored, leave it; do NOT commit `package-lock.json`).
 
-- [ ] **Step 3: Backend smoke checks**
+- [ ] **Step 3: Backend suite + smoke checks**
 
 ```bash
-php artisan migrate:status | tail -5
+docker compose run --rm phpunit
 php artisan route:list --path=pos-api > /dev/null && echo POS-API-OK
 php artisan route:list --path=api/v1 > /dev/null && echo MGMT-API-OK
 ```
-Expected: both new migrations `Ran`; `POS-API-OK`, `MGMT-API-OK`.
+Expected: full phpunit suite green; `POS-API-OK`, `MGMT-API-OK`.
 
 - [ ] **Step 4: Manual end-to-end checklist (requires running app + paired device; report what was and wasn't checked)**
 

--- a/docs/superpowers/specs/2026-07-08-device-capability-flags-design.md
+++ b/docs/superpowers/specs/2026-07-08-device-capability-flags-design.md
@@ -103,9 +103,9 @@ handling.
 
 ## 5. Unauthorized-transaction audit flag
 
-In the Device API transaction upload path
-(`App\Http\Shared\V1\Controllers\TransactionController::beforeSaveEntity`,
-device context):
+In the Device API transaction upload path (`App\Tools\TransactionMerger`,
+constructed with the authenticated device by
+`App\Http\DeviceApi\V1\Controllers\TransactionController::mergeTransactions`):
 
 1. Always set `uploaded_by_device_id` to the authenticated device's id when
    the principal is a `Device`.
@@ -126,10 +126,11 @@ transactions overview.
 
 ## 6. Testing
 
-- No PHP test suite exists; backend verified manually: run migration, check
-  `php artisan route:list`, verify Management API accepts the fields and
-  Device API ignores writes to them, verify a topup transaction uploaded by a
-  restricted device gets flagged.
+- Backend: PHPUnit feature tests (`tests/Feature/`, run via
+  `docker compose run --rm phpunit`) cover the capability defaults, the
+  Device API read-only boundary, the Management API write path, the
+  unauthorized-flagging rules in `TransactionMerger` (including the
+  positive-value rule), and order-assignment exclusion.
 - Frontend: Vitest tests for the POS route guard / nav gating, following the
   existing route/view test pattern in `resources/tests/`.
 - Jest NFC tests unaffected (no changes to card format or signing).

--- a/docs/superpowers/specs/2026-07-08-device-capability-flags-design.md
+++ b/docs/superpowers/specs/2026-07-08-device-capability-flags-design.md
@@ -1,0 +1,144 @@
+# Device Capability Flags: Sales / Topup
+
+**Date:** 2026-07-08
+**Status:** Approved
+
+## Problem
+
+Every paired POS device can top up, reset, and rebuild NFC cards via the Cards
+page. At festivals, organisers want dedicated topup stations staffed by trusted
+people, while bar devices should only sell. Bar volunteers must not be able to
+top up or reset cards — and must not be able to grant themselves that ability.
+
+## Solution overview
+
+Two new admin-controlled boolean capability flags on the `Device` model:
+
+| Flag | Default | Gates |
+|------|---------|-------|
+| `allow_sales` | `true` | Order processing: events UI, live + remote orders |
+| `allow_topup` | `true` | The Cards page: topup, reset, rebuild, discount, aliases |
+
+Both flags are editable **only** through the Management API. The Device API
+exposes them read-only, so a device cannot change its own capabilities. The POS
+hides the corresponding UI. Because card writes happen offline with the
+device's signing key, the server cannot physically prevent a rogue topup;
+instead it **flags** unauthorized topup/reset/refund transactions at upload
+time so admins can detect misuse.
+
+## 1. Data model
+
+Migration adds to `devices`:
+
+- `allow_sales` — boolean, default `true`
+- `allow_topup` — boolean, default `true`
+
+Defaults keep existing devices fully functional after upgrade.
+
+Migration adds to `card_transactions`:
+
+- `uploaded_by_device_id` — nullable unsigned FK to `devices.id`, set on every
+  transaction uploaded through the Device API (general audit value)
+- `unauthorized` — boolean, default `false`
+
+`Device` model: add both flags to `$fillable` and `$casts`. The existing
+`static::updated` reassignment hook also triggers when `allow_sales` is
+switched off (same treatment as `allow_remote_orders` being disabled).
+
+`Transaction` model: add `unauthorized` cast; add `uploadedByDevice()`
+relationship.
+
+## 2. API exposure (security boundary)
+
+- `App\Http\ManagementApi\V1\ResourceDefinitions\DeviceResourceDefinition`:
+  both fields `->bool()->visible(true)->writeable(true, true)`.
+- `App\Http\DeviceApi\V1\ResourceDefinitions\DeviceResourceDefinition`:
+  both fields `->bool()->visible(true)->writeable(false)`.
+
+Charon does not apply non-writeable fields on input, so
+`PUT /pos-api/v1/devices/current` silently ignores attempts to set them. No
+policy changes required — `DevicePolicy` self-edit stays as is.
+
+## 3. Manage UI
+
+`resources/manage/js/views/Devices.vue`:
+
+- Edit-device modal (currently name only) gains two checkboxes:
+  "Allow sales" and "Allow card topups". `saveEdit()` sends both fields.
+- Device list shows compact badges per device (e.g. "sales", "topup") so the
+  role split is visible at a glance.
+
+## 4. POS behavior
+
+The POS already fetches and offline-caches `GET /pos-api/v1/devices/current`
+at boot (`resources/pos/js/app.js`). Expose:
+
+- `window.DEVICE_ALLOW_SALES` (default `true` when absent)
+- `window.DEVICE_ALLOW_TOPUP` (default `true` when absent)
+
+Gating (all in the POS app only; Manage is unaffected):
+
+- **`allow_topup = false`:**
+  - "Cards" navbar item hidden (`resources/pos/js/views/App.vue`)
+  - `/cards` and `/transactions` routes redirect to the default landing page
+- **`allow_sales = false`:**
+  - "Events" navbar item hidden
+  - Event routes (`/events`, `/events/:id/*`) redirect to the default landing
+    page
+  - Live/remote order toggles hidden in POS Settings
+    (`resources/pos/js/views/Settings.vue`)
+  - Default landing route becomes `/cards` instead of the events list
+- **Both `false`:** an explanatory screen ("This device has no functions
+  enabled. Contact your administrator.") — reachable settings page stays
+  available for sync/logout.
+
+Route gating is implemented with a router `beforeEach` guard (or per-route
+`beforeEnter`) reading the window flags, so deep links are covered, not just
+nav visibility.
+
+Server side, `App\Services\OrderAssignmentService` excludes devices with
+`allow_sales = false` from remote-order assignment (both in the eligibility
+check and the assignment query), mirroring the `allow_remote_orders`
+handling.
+
+## 5. Unauthorized-transaction audit flag
+
+In the Device API transaction upload path
+(`App\Http\Shared\V1\Controllers\TransactionController::beforeSaveEntity`,
+device context):
+
+1. Always set `uploaded_by_device_id` to the authenticated device's id when
+   the principal is a `Device`.
+2. If `transaction_type` ∈ {`topup`, `reset`, `refund`} **and** the uploading
+   device has `allow_topup = false`, set `unauthorized = true`. The
+   transaction is still saved (rejecting it would desync the books from the
+   card, which already carries the balance).
+
+Exposure:
+
+- `TransactionResourceDefinition` (Management API): `unauthorized` visible,
+  not writeable.
+- Manage Transactions overview (`TransactionsTable.vue` /
+  `Transactions.vue`): red "unauthorized" badge on flagged rows.
+
+Out of scope: notifications/alerts on flagged transactions; admins review the
+transactions overview.
+
+## 6. Testing
+
+- No PHP test suite exists; backend verified manually: run migration, check
+  `php artisan route:list`, verify Management API accepts the fields and
+  Device API ignores writes to them, verify a topup transaction uploaded by a
+  restricted device gets flagged.
+- Frontend: Vitest tests for the POS route guard / nav gating, following the
+  existing route/view test pattern in `resources/tests/`.
+- Jest NFC tests unaffected (no changes to card format or signing).
+
+## Out of scope
+
+- No changes to the NFC key approval system: a sales-only device keeps its
+  approved signing key because deducting balances during sales requires it.
+- No mode enum / migration of `allow_live_orders` / `allow_remote_orders`;
+  those flags remain device-editable and govern *how* a sales-enabled device
+  sells.
+- No PIN-override mechanism to temporarily unlock topup on a device.

--- a/docs/superpowers/specs/2026-07-08-device-capability-flags-design.md
+++ b/docs/superpowers/specs/2026-07-08-device-capability-flags-design.md
@@ -134,6 +134,20 @@ transactions overview.
   existing route/view test pattern in `resources/tests/`.
 - Jest NFC tests unaffected (no changes to card format or signing).
 
+## Known limitations
+
+- A rogue device can inflate a card's balance offline and never upload a
+  typed transaction for it; the delta only later syncs as an unflagged
+  `unknown`/overflow transaction via the card-data path. Attribution exists
+  via the card's `last_signing_device_id`, but no `unauthorized` badge is
+  raised for this path.
+- A fabricated positive `reversal` upload from a sales-only device is not
+  flagged, since legitimate reversals are positive on such devices; it still
+  carries `uploaded_by_device_id` so it can be reviewed manually.
+- The `unauthorized` flag is detection, not prevention: offline card writes
+  cannot be rejected server-side, because the card already carries the
+  balance and the server only sees the upload after the fact.
+
 ## Out of scope
 
 - No changes to the NFC key approval system: a sales-only device keeps its

--- a/resources/manage/js/views/Devices.vue
+++ b/resources/manage/js/views/Devices.vue
@@ -53,6 +53,12 @@
 						</span>
 					</template>
 
+					<template v-slot:cell(capabilities)="row">
+						<span v-if="row.item.allow_sales !== false" class="badge badge-info mr-1">{{ $t('Sales') }}</span>
+						<span v-if="row.item.allow_topup !== false" class="badge badge-success">{{ $t('Topup') }}</span>
+						<span v-if="row.item.allow_sales === false && row.item.allow_topup === false" class="badge badge-danger">{{ $t('Disabled') }}</span>
+					</template>
+
 					<template v-slot:cell(pending_orders)="row">
 						{{ row.item.pending_orders_count || 0 }}
 					</template>
@@ -189,6 +195,18 @@
 			<b-form-input id="edit-device-name" type="text" v-model="editModel.name" :placeholder="$t('Enter device name')" />
 		</b-form-group>
 
+		<b-form-group :description="$t('This device can process orders and sales.')">
+			<b-form-checkbox v-model="editModel.allow_sales">
+				{{ $t('Allow sales') }}
+			</b-form-checkbox>
+		</b-form-group>
+
+		<b-form-group :description="$t('This device can topup, reset and manage NFC cards.')">
+			<b-form-checkbox v-model="editModel.allow_topup">
+				{{ $t('Allow card topups') }}
+			</b-form-checkbox>
+		</b-form-group>
+
 		<template #modal-footer>
 			<b-btn type="button" variant="light" @click="resetEditForm()">{{ $t('Cancel') }}</b-btn>
 			<b-btn type="button" variant="success" @click="saveEdit()">
@@ -265,6 +283,10 @@
 					{
 						key: 'status',
 						label: this.$t('Status'),
+					},
+					{
+						key: 'capabilities',
+						label: this.$t('Capabilities'),
 					},
 					{
 						key: 'pending_orders',
@@ -373,7 +395,11 @@
 			},
 
 			async saveEdit() {
-				await this.service.update(this.editModel.id, { name: this.editModel.name });
+				await this.service.update(this.editModel.id, {
+					name: this.editModel.name,
+					allow_sales: !!this.editModel.allow_sales,
+					allow_topup: !!this.editModel.allow_topup
+				});
 				this.resetEditForm();
 				this.refreshDevices();
 			},

--- a/resources/pos/js/app.js
+++ b/resources/pos/js/app.js
@@ -56,6 +56,8 @@ import Relax from "../../shared/js/components/Relax";
 
 import Authenticate from "./views/Authenticate";
 import { getAuthData, clearAuthData } from "../../shared/js/services/DeviceAuth";
+import Disabled from './views/Disabled.vue';
+import { getDeviceCapabilities, resolveCapabilityRedirect } from './deviceCapabilities';
 
 async function launch() {
 
@@ -204,8 +206,23 @@ async function launch() {
 				path: '/financial-overview',
 				name: 'financialOverview',
 				component: FinancialOverview
+			},
+
+			{
+				path: '/disabled',
+				name: 'disabled',
+				component: Disabled
 			}
 		],
+	});
+
+	router.beforeEach((to, from, next) => {
+		const redirect = resolveCapabilityRedirect(to.name, getDeviceCapabilities());
+		if (redirect) {
+			next({ name: redirect });
+		} else {
+			next();
+		}
 	});
 
 	/**
@@ -243,6 +260,8 @@ async function launch() {
 				window.DEVICE_NAME = deviceData.name;
 				window.DEVICE_APPROVED_AT = deviceData.approved_at || null;
 				window.DEVICE_PUBLIC_KEY = deviceData.public_key || null;
+				window.DEVICE_ALLOW_SALES = deviceData.allow_sales !== false;
+				window.DEVICE_ALLOW_TOPUP = deviceData.allow_topup !== false;
 
 				// Set device license if LicenseService is available
 				if (deviceData.license_key && typeof(window.CATLAB_DRINKS_APP) !== 'undefined' && window.CATLAB_DRINKS_APP.LicenseService) {

--- a/resources/pos/js/deviceCapabilities.js
+++ b/resources/pos/js/deviceCapabilities.js
@@ -1,0 +1,57 @@
+/*
+ * Device capability gating for the POS app.
+ *
+ * allow_sales / allow_topup are admin-controlled flags loaded from
+ * GET /pos-api/v1/devices/current at boot. Missing flags (old cached
+ * responses) are treated as enabled so existing devices keep working.
+ */
+
+// Route names that require the sales capability.
+const SALES_ROUTES = [
+	'home',
+	'events',
+	'menu',
+	'hq',
+	'sales',
+	'summary',
+	'summary-names',
+	'attendees',
+	'checkIn',
+];
+
+// Route names that require the topup capability.
+const TOPUP_ROUTES = [
+	'cards',
+	'transactions',
+	'testTransactions',
+];
+
+export function getDeviceCapabilities() {
+	return {
+		allowSales: window.DEVICE_ALLOW_SALES !== false,
+		allowTopup: window.DEVICE_ALLOW_TOPUP !== false,
+	};
+}
+
+/**
+ * Decide whether navigation to a route is allowed.
+ * Returns the route name to redirect to, or null when allowed.
+ */
+export function resolveCapabilityRedirect(routeName, capabilities) {
+	const { allowSales, allowTopup } = capabilities;
+
+	if (!allowSales && SALES_ROUTES.indexOf(routeName) !== -1) {
+		return allowTopup ? 'cards' : 'disabled';
+	}
+
+	if (!allowTopup && TOPUP_ROUTES.indexOf(routeName) !== -1) {
+		return allowSales ? 'events' : 'disabled';
+	}
+
+	if (routeName === 'disabled' && (allowSales || allowTopup)) {
+		// Device regained a capability; leave the dead-end screen.
+		return allowSales ? 'events' : 'cards';
+	}
+
+	return null;
+}

--- a/resources/pos/js/views/App.vue
+++ b/resources/pos/js/views/App.vue
@@ -43,7 +43,7 @@
 			<b-collapse is-nav id="nav_collapse">
 				<b-navbar-nav>
 
-					<b-nav-item :to="{ name: 'events' }"  v-if="!kioskMode">{{ $t('Events') }}</b-nav-item>
+					<b-nav-item :to="{ name: 'events' }"  v-if="!kioskMode && allowSales">{{ $t('Events') }}</b-nav-item>
 
 				</b-navbar-nav>
 
@@ -52,7 +52,7 @@
 
 					<b-navbar-nav>
 
-						<b-nav-item :to="{ name: 'cards' }">{{ $t('Cards') }}</b-nav-item>
+						<b-nav-item :to="{ name: 'cards' }" v-if="allowTopup">{{ $t('Cards') }}</b-nav-item>
 						<b-nav-item :to="{ name: 'settings' }">{{ $t('Settings') }}</b-nav-item>
 						<language-toggle />
 
@@ -195,6 +195,8 @@
 		data() {
 			return {
 				kioskMode: false,
+				allowSales: window.DEVICE_ALLOW_SALES !== false,
+				allowTopup: window.DEVICE_ALLOW_TOPUP !== false,
 				isOffline: false,
 				showLicenseWarning: false,
 				showLicenseErrorModal: false,

--- a/resources/pos/js/views/Disabled.vue
+++ b/resources/pos/js/views/Disabled.vue
@@ -1,0 +1,33 @@
+<!--
+  - CatLab Drinks - Simple bar automation system
+  - Copyright (C) 2019 Thijs Van der Schaeghe
+  - CatLab Interactive bvba, Gent, Belgium
+  - http://www.catlab.eu/
+  -
+  - This program is free software; you can redistribute it and/or modify
+  - it under the terms of the GNU General Public License as published by
+  - the Free Software Foundation; either version 3 of the License, or
+  - (at your option) any later version.
+  -
+  - This program is distributed in the hope that it will be useful,
+  - but WITHOUT ANY WARRANTY; without even the implied warranty of
+  - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  - GNU General Public License for more details.
+  -
+  - You should have received a copy of the GNU General Public License along
+  - with this program; if not, write to the Free Software Foundation, Inc.,
+  - 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+  -->
+
+<template>
+	<b-container fluid>
+		<b-alert variant="warning" :show="true" class="mt-3 text-center">
+			<p class="mb-1"><strong>{{ $t('This device has no functions enabled.') }}</strong></p>
+			<p class="mb-0">{{ $t('Please contact your administrator to enable sales or topups for this device.') }}</p>
+		</b-alert>
+	</b-container>
+</template>
+
+<script>
+	export default {};
+</script>

--- a/resources/pos/js/views/Settings.vue
+++ b/resources/pos/js/views/Settings.vue
@@ -52,25 +52,27 @@
 							></b-form-input>
 						</b-form-group>
 
-						<b-form-group
-							id="allow_live_orders"
-							:description="$t('This terminal can process orders at the bar')"
-						>
-							<label>
-								<input type="checkbox" v-model="allowLiveOrders"></input>
-								{{ $t('Allow live orders at this terminal') }}<br />
-							</label>
-						</b-form-group>
+						<template v-if="allowSales">
+							<b-form-group
+								id="allow_live_orders"
+								:description="$t('This terminal can process orders at the bar')"
+							>
+								<label>
+									<input type="checkbox" v-model="allowLiveOrders"></input>
+									{{ $t('Allow live orders at this terminal') }}<br />
+								</label>
+							</b-form-group>
 
-						<b-form-group
-							id="allow_remote_orders"
-							:description="$t('This terminal can process orders from tables')"
-						>
-							<label>
-								<input type="checkbox" v-model="allowRemoteOrders"></input>
-								{{ $t('Allow remote orders at this terminal') }}<br />
-							</label>
-						</b-form-group>
+							<b-form-group
+								id="allow_remote_orders"
+								:description="$t('This terminal can process orders from tables')"
+							>
+								<label>
+									<input type="checkbox" v-model="allowRemoteOrders"></input>
+									{{ $t('Allow remote orders at this terminal') }}<br />
+								</label>
+							</b-form-group>
+						</template>
 
 					</b-form-fieldset>
 
@@ -270,6 +272,8 @@
 
 				allowLiveOrders: false,
 				allowRemoteOrders: false,
+
+				allowSales: window.DEVICE_ALLOW_SALES !== false,
 
 				licenseStatus: null,
 

--- a/resources/shared/js/components/Card.vue
+++ b/resources/shared/js/components/Card.vue
@@ -29,49 +29,51 @@
                 <p>
                     {{ $t('This card is corrupted, it might belong to a different organisation. If you are sure the card should be correct, you can try to rebuild the card data from the available online data. Note that if you have bars that are operating online, you might lose transactions and the balance might not be correct after rebuilding.') }}
                 </p>
-                <button v-on:click="rebuild()" class="btn btn-danger">{{ $t('Rebuild') }}</button>
+                <button v-on:click="rebuild()" class="btn btn-danger" v-if="allowTopup">{{ $t('Rebuild') }}</button>
             </div>
         </div>
 
         <div v-if="ready" class="row">
 
             <div class="col-md-8">
-                <h2>{{ $t('Topup') }}</h2>
-                <div class="topup-amounts">
-                    <div v-for="amount in defaultAmounts" v-on:click="topupForAmount(amount)" class="amount">
-                        €{{ amount.toFixed(2) }}
+                <template v-if="allowTopup">
+                    <h2>{{ $t('Topup') }}</h2>
+                    <div class="topup-amounts">
+                        <div v-for="amount in defaultAmounts" v-on:click="topupForAmount(amount)" class="amount">
+                            €{{ amount.toFixed(2) }}
+                        </div>
                     </div>
-                </div>
 
-                <div style="clear: both;"></div>
+                    <div style="clear: both;"></div>
 
-                <h3>{{ $t('Custom amount') }}</h3>
-                <label for="customAmount">{{ $t('Custom amount') }}</label><br />
-                <input type="number" step="0.01" placeholder="10.00" id="customAmount" v-model="topupAmountString" />
+                    <h3>{{ $t('Custom amount') }}</h3>
+                    <label for="customAmount">{{ $t('Custom amount') }}</label><br />
+                    <input type="number" step="0.01" placeholder="10.00" id="customAmount" v-model="topupAmountString" />
 
-                <button class="btn btn-primary" v-on:click="topup()">{{ $t('Topup') }}</button>
+                    <button class="btn btn-primary" v-on:click="topup()">{{ $t('Topup') }}</button>
 
-                <h3>{{ $t('Aliases') }}</h3>
-                <p>{{ $t('(expire 24h after creation)') }}</p>
-                <ul>
-                    <li v-for="alias in card.orderTokenAliases">{{alias}} <a href="javascript:void(0);" v-on:click="removeOrderTokenAlias(alias)" class="btn btn-danger btn-sm">x</a></li>
+                    <h3>{{ $t('Aliases') }}</h3>
+                    <p>{{ $t('(expire 24h after creation)') }}</p>
+                    <ul>
+                        <li v-for="alias in card.orderTokenAliases">{{alias}} <a href="javascript:void(0);" v-on:click="removeOrderTokenAlias(alias)" class="btn btn-danger btn-sm">x</a></li>
 
-                    <li>
-                        <input type="text" v-model="creatingOrderTokenAlias" />
-                        <button class="btn btn-primary btn-sm" v-on:click="addOrderTokenAlias">{{ $t('Add') }}</button>
-                    </li>
-                </ul>
+                        <li>
+                            <input type="text" v-model="creatingOrderTokenAlias" />
+                            <button class="btn btn-primary btn-sm" v-on:click="addOrderTokenAlias">{{ $t('Add') }}</button>
+                        </li>
+                    </ul>
 
-                <h3>{{ $t('Discount') }}</h3>
-                <p>
-                    {{ $t('Card gives') }} <input type="number" step="1" min="0.0" max="100.0" v-model="card.discountPercentage" />{{ $t('% at all sales.') }}
-                    <button class="btn btn-primary btn-sm" v-on:click="saveCardData">{{ $t('Save') }}</button>
-                </p>
+                    <h3>{{ $t('Discount') }}</h3>
+                    <p>
+                        {{ $t('Card gives') }} <input type="number" step="1" min="0.0" max="100.0" v-model="card.discountPercentage" />{{ $t('% at all sales.') }}
+                        <button class="btn btn-primary btn-sm" v-on:click="saveCardData">{{ $t('Save') }}</button>
+                    </p>
 
-                <p>
-                    <span v-if="storeState === 'storing'">{{ $t('Saving') }}</span>
-                    <span v-if="storeState === 'stored'">{{ $t('Saved') }}</span>
-                </p>
+                    <p>
+                        <span v-if="storeState === 'storing'">{{ $t('Saving') }}</span>
+                        <span v-if="storeState === 'stored'">{{ $t('Saved') }}</span>
+                    </p>
+                </template>
             </div>
 
             <div class="col-md-4">
@@ -100,7 +102,7 @@
                 <h3>{{ $t('Transactions') }}</h3>
                 <transactions-table v-if="loaded" :cardId="card.id" />
 
-                <p>
+                <p v-if="allowTopup">
                     <button v-on:click="reset()" class="btn btn-info btn-sm">{{ $t('Reset') }}</button>
                     <button v-on:click="rebuild()" class="btn btn-danger btn-sm">{{ $t('Rebuild') }}</button>
                 </p>
@@ -154,6 +156,7 @@
         data() {
             return {
                 canTopup: false,
+                allowTopup: window.DEVICE_ALLOW_TOPUP !== false,
                 loaded: false,
 				ready: false,
 				corrupted: false,

--- a/resources/shared/js/components/TransactionsTable.vue
+++ b/resources/shared/js/components/TransactionsTable.vue
@@ -39,6 +39,7 @@
                     <a href="javascript:void(0)" class="btn btn-sm btn-info" v-on:click="showOrder(row.item.order)">Order #{{row.item.order.id}}</a>
                 </span>
                 <span v-else>{{ row.item.type }}</span>
+                <span v-if="row.item.unauthorized" class="badge badge-danger ml-1" :title="$t('This transaction was uploaded by a device that is not allowed to topup cards.')">{{ $t('Unauthorized') }}</span>
             </template>
 
             <template v-slot:cell(amount)="row">

--- a/resources/shared/js/i18n/de.js
+++ b/resources/shared/js/i18n/de.js
@@ -432,4 +432,6 @@ export default {
     'Disabled': 'Deaktiviert',
     'This device has no functions enabled.': 'Für dieses Gerät sind keine Funktionen aktiviert.',
     'Please contact your administrator to enable sales or topups for this device.': 'Bitte kontaktiere deinen Administrator, um Verkäufe oder Aufladungen für dieses Gerät zu aktivieren.',
+    'Unauthorized': 'Nicht autorisiert',
+    'This transaction was uploaded by a device that is not allowed to topup cards.': 'Diese Transaktion wurde von einem Gerät hochgeladen, das keine Karten aufladen darf.',
 };

--- a/resources/shared/js/i18n/de.js
+++ b/resources/shared/js/i18n/de.js
@@ -430,4 +430,6 @@ export default {
     'Capabilities': 'Funktionen',
     'Sales': 'Verkauf',
     'Disabled': 'Deaktiviert',
+    'This device has no functions enabled.': 'Für dieses Gerät sind keine Funktionen aktiviert.',
+    'Please contact your administrator to enable sales or topups for this device.': 'Bitte kontaktiere deinen Administrator, um Verkäufe oder Aufladungen für dieses Gerät zu aktivieren.',
 };

--- a/resources/shared/js/i18n/de.js
+++ b/resources/shared/js/i18n/de.js
@@ -421,4 +421,13 @@ export default {
     'This is the hello world.': 'Dies ist die Hallo-Welt.',
     'Home': 'Startseite',
     'This is the home.': 'Dies ist die Startseite.',
+
+    // Device capabilities
+    'Allow sales': 'Verkäufe erlauben',
+    'Allow card topups': 'Kartenaufladung erlauben',
+    'This device can process orders and sales.': 'Dieses Gerät kann Bestellungen und Verkäufe verarbeiten.',
+    'This device can topup, reset and manage NFC cards.': 'Dieses Gerät kann NFC-Karten aufladen, zurücksetzen und verwalten.',
+    'Capabilities': 'Funktionen',
+    'Sales': 'Verkauf',
+    'Disabled': 'Deaktiviert',
 };

--- a/resources/shared/js/i18n/en.js
+++ b/resources/shared/js/i18n/en.js
@@ -432,4 +432,6 @@ export default {
     'Disabled': 'Disabled',
     'This device has no functions enabled.': 'This device has no functions enabled.',
     'Please contact your administrator to enable sales or topups for this device.': 'Please contact your administrator to enable sales or topups for this device.',
+    'Unauthorized': 'Unauthorized',
+    'This transaction was uploaded by a device that is not allowed to topup cards.': 'This transaction was uploaded by a device that is not allowed to topup cards.',
 };

--- a/resources/shared/js/i18n/en.js
+++ b/resources/shared/js/i18n/en.js
@@ -430,4 +430,6 @@ export default {
     'Capabilities': 'Capabilities',
     'Sales': 'Sales',
     'Disabled': 'Disabled',
+    'This device has no functions enabled.': 'This device has no functions enabled.',
+    'Please contact your administrator to enable sales or topups for this device.': 'Please contact your administrator to enable sales or topups for this device.',
 };

--- a/resources/shared/js/i18n/en.js
+++ b/resources/shared/js/i18n/en.js
@@ -421,4 +421,13 @@ export default {
     'This is the hello world.': 'This is the hello world.',
     'Home': 'Home',
     'This is the home.': 'This is the home.',
+
+    // Device capabilities
+    'Allow sales': 'Allow sales',
+    'Allow card topups': 'Allow card topups',
+    'This device can process orders and sales.': 'This device can process orders and sales.',
+    'This device can topup, reset and manage NFC cards.': 'This device can topup, reset and manage NFC cards.',
+    'Capabilities': 'Capabilities',
+    'Sales': 'Sales',
+    'Disabled': 'Disabled',
 };

--- a/resources/shared/js/i18n/es.js
+++ b/resources/shared/js/i18n/es.js
@@ -421,4 +421,13 @@ export default {
     'This is the hello world.': 'Esta es la página hola mundo.',
     'Home': 'Inicio',
     'This is the home.': 'Esta es la página de inicio.',
+
+    // Device capabilities
+    'Allow sales': 'Permitir ventas',
+    'Allow card topups': 'Permitir recargas de tarjetas',
+    'This device can process orders and sales.': 'Este dispositivo puede procesar pedidos y ventas.',
+    'This device can topup, reset and manage NFC cards.': 'Este dispositivo puede recargar, restablecer y gestionar tarjetas NFC.',
+    'Capabilities': 'Capacidades',
+    'Sales': 'Ventas',
+    'Disabled': 'Desactivado',
 };

--- a/resources/shared/js/i18n/es.js
+++ b/resources/shared/js/i18n/es.js
@@ -432,4 +432,6 @@ export default {
     'Disabled': 'Desactivado',
     'This device has no functions enabled.': 'Este dispositivo no tiene funciones habilitadas.',
     'Please contact your administrator to enable sales or topups for this device.': 'Ponte en contacto con tu administrador para habilitar ventas o recargas en este dispositivo.',
+    'Unauthorized': 'No autorizado',
+    'This transaction was uploaded by a device that is not allowed to topup cards.': 'Esta transacción fue subida por un dispositivo que no puede recargar tarjetas.',
 };

--- a/resources/shared/js/i18n/es.js
+++ b/resources/shared/js/i18n/es.js
@@ -430,4 +430,6 @@ export default {
     'Capabilities': 'Capacidades',
     'Sales': 'Ventas',
     'Disabled': 'Desactivado',
+    'This device has no functions enabled.': 'Este dispositivo no tiene funciones habilitadas.',
+    'Please contact your administrator to enable sales or topups for this device.': 'Ponte en contacto con tu administrador para habilitar ventas o recargas en este dispositivo.',
 };

--- a/resources/shared/js/i18n/fr.js
+++ b/resources/shared/js/i18n/fr.js
@@ -430,4 +430,6 @@ export default {
     'Capabilities': 'Fonctions',
     'Sales': 'Ventes',
     'Disabled': 'Désactivé',
+    'This device has no functions enabled.': 'Cet appareil n\'a aucune fonction activée.',
+    'Please contact your administrator to enable sales or topups for this device.': 'Veuillez contacter votre administrateur pour activer les ventes ou les rechargements pour cet appareil.',
 };

--- a/resources/shared/js/i18n/fr.js
+++ b/resources/shared/js/i18n/fr.js
@@ -432,4 +432,6 @@ export default {
     'Disabled': 'Désactivé',
     'This device has no functions enabled.': 'Cet appareil n\'a aucune fonction activée.',
     'Please contact your administrator to enable sales or topups for this device.': 'Veuillez contacter votre administrateur pour activer les ventes ou les rechargements pour cet appareil.',
+    'Unauthorized': 'Non autorisé',
+    'This transaction was uploaded by a device that is not allowed to topup cards.': 'Cette transaction a été envoyée par un appareil qui n\'est pas autorisé à recharger les cartes.',
 };

--- a/resources/shared/js/i18n/fr.js
+++ b/resources/shared/js/i18n/fr.js
@@ -421,4 +421,13 @@ export default {
     'This is the hello world.': 'Ceci est le bonjour le monde.',
     'Home': 'Accueil',
     'This is the home.': 'Ceci est la page d\'accueil.',
+
+    // Device capabilities
+    'Allow sales': 'Autoriser les ventes',
+    'Allow card topups': 'Autoriser le rechargement des cartes',
+    'This device can process orders and sales.': 'Cet appareil peut traiter les commandes et les ventes.',
+    'This device can topup, reset and manage NFC cards.': 'Cet appareil peut recharger, réinitialiser et gérer les cartes NFC.',
+    'Capabilities': 'Fonctions',
+    'Sales': 'Ventes',
+    'Disabled': 'Désactivé',
 };

--- a/resources/shared/js/i18n/nl.js
+++ b/resources/shared/js/i18n/nl.js
@@ -430,4 +430,6 @@ export default {
     'Capabilities': 'Functies',
     'Sales': 'Verkoop',
     'Disabled': 'Uitgeschakeld',
+    'This device has no functions enabled.': 'Dit apparaat heeft geen functies ingeschakeld.',
+    'Please contact your administrator to enable sales or topups for this device.': 'Neem contact op met je beheerder om verkoop of opwaarderen voor dit apparaat in te schakelen.',
 };

--- a/resources/shared/js/i18n/nl.js
+++ b/resources/shared/js/i18n/nl.js
@@ -432,4 +432,6 @@ export default {
     'Disabled': 'Uitgeschakeld',
     'This device has no functions enabled.': 'Dit apparaat heeft geen functies ingeschakeld.',
     'Please contact your administrator to enable sales or topups for this device.': 'Neem contact op met je beheerder om verkoop of opwaarderen voor dit apparaat in te schakelen.',
+    'Unauthorized': 'Niet toegestaan',
+    'This transaction was uploaded by a device that is not allowed to topup cards.': 'Deze transactie werd geüpload door een apparaat dat geen kaarten mag opwaarderen.',
 };

--- a/resources/shared/js/i18n/nl.js
+++ b/resources/shared/js/i18n/nl.js
@@ -421,4 +421,13 @@ export default {
     'This is the hello world.': 'Dit is de hallo wereld.',
     'Home': 'Startpagina',
     'This is the home.': 'Dit is de startpagina.',
+
+    // Device capabilities
+    'Allow sales': 'Verkoop toestaan',
+    'Allow card topups': 'Kaarten opwaarderen toestaan',
+    'This device can process orders and sales.': 'Dit apparaat kan bestellingen en verkopen verwerken.',
+    'This device can topup, reset and manage NFC cards.': 'Dit apparaat kan NFC-kaarten opwaarderen, resetten en beheren.',
+    'Capabilities': 'Functies',
+    'Sales': 'Verkoop',
+    'Disabled': 'Uitgeschakeld',
 };

--- a/resources/shared/js/nfccards/models/Transaction.ts
+++ b/resources/shared/js/nfccards/models/Transaction.ts
@@ -27,6 +27,8 @@ export class Transaction {
 
     public uploaded = false;
 
+    public unauthorized = false;
+
     public order: any = null;
 
     public topup: any = null;

--- a/resources/shared/js/nfccards/store/TransactionStore.ts
+++ b/resources/shared/js/nfccards/store/TransactionStore.ts
@@ -361,6 +361,7 @@ export class TransactionStore {
 
                 transaction.id = item.id;
                 transaction.uploaded = true;
+                transaction.unauthorized = !!item.unauthorized;
 
                 if (item.order) {
                     transaction.order = item.order;

--- a/resources/tests/card-topup-gating.test.js
+++ b/resources/tests/card-topup-gating.test.js
@@ -1,0 +1,26 @@
+/**
+ * Tests for Card.vue topup UI gating (allow_topup capability flag).
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+describe('Card.vue topup gating', () => {
+	const source = readFileSync(resolve(__dirname, '..', 'shared', 'js', 'components', 'Card.vue'), 'utf-8');
+
+	it('reads the allow_topup capability flag with the Manage-safe idiom', () => {
+		expect(source).toContain('window.DEVICE_ALLOW_TOPUP !== false');
+	});
+
+	it('gates the card-mutating UI on allowTopup', () => {
+		expect(source).toContain('v-if="allowTopup"');
+	});
+});
+
+describe('CheckIn.vue', () => {
+	const source = readFileSync(resolve(__dirname, '..', 'shared', 'js', 'views', 'CheckIn.vue'), 'utf-8');
+
+	it('still mounts the card component', () => {
+		expect(source).toContain('<card');
+	});
+});

--- a/resources/tests/device-capabilities.test.js
+++ b/resources/tests/device-capabilities.test.js
@@ -1,0 +1,94 @@
+/**
+ * Tests for POS device capability gating (allow_sales / allow_topup).
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import { getDeviceCapabilities, resolveCapabilityRedirect } from '../pos/js/deviceCapabilities';
+
+const BOTH = { allowSales: true, allowTopup: true };
+const SALES_ONLY = { allowSales: true, allowTopup: false };
+const TOPUP_ONLY = { allowSales: false, allowTopup: true };
+const NONE = { allowSales: false, allowTopup: false };
+
+describe('resolveCapabilityRedirect', () => {
+
+	it('allows everything when both capabilities are enabled', () => {
+		['home', 'events', 'hq', 'cards', 'transactions', 'settings'].forEach((name) => {
+			expect(resolveCapabilityRedirect(name, BOTH)).toBeNull();
+		});
+	});
+
+	it('redirects card routes to events on sales-only devices', () => {
+		expect(resolveCapabilityRedirect('cards', SALES_ONLY)).toBe('events');
+		expect(resolveCapabilityRedirect('transactions', SALES_ONLY)).toBe('events');
+		expect(resolveCapabilityRedirect('testTransactions', SALES_ONLY)).toBe('events');
+	});
+
+	it('keeps sales routes accessible on sales-only devices', () => {
+		expect(resolveCapabilityRedirect('events', SALES_ONLY)).toBeNull();
+		expect(resolveCapabilityRedirect('hq', SALES_ONLY)).toBeNull();
+	});
+
+	it('redirects sales routes to cards on topup-only devices', () => {
+		['home', 'events', 'menu', 'hq', 'sales', 'summary', 'summary-names', 'attendees', 'checkIn'].forEach((name) => {
+			expect(resolveCapabilityRedirect(name, TOPUP_ONLY)).toBe('cards');
+		});
+	});
+
+	it('keeps card routes accessible on topup-only devices', () => {
+		expect(resolveCapabilityRedirect('cards', TOPUP_ONLY)).toBeNull();
+		expect(resolveCapabilityRedirect('transactions', TOPUP_ONLY)).toBeNull();
+	});
+
+	it('redirects everything gated to the disabled screen when nothing is allowed', () => {
+		expect(resolveCapabilityRedirect('events', NONE)).toBe('disabled');
+		expect(resolveCapabilityRedirect('cards', NONE)).toBe('disabled');
+	});
+
+	it('always allows settings and the disabled screen itself', () => {
+		expect(resolveCapabilityRedirect('settings', NONE)).toBeNull();
+		expect(resolveCapabilityRedirect('disabled', NONE)).toBeNull();
+	});
+
+	it('bounces away from the disabled screen when capabilities exist', () => {
+		expect(resolveCapabilityRedirect('disabled', BOTH)).toBe('events');
+		expect(resolveCapabilityRedirect('disabled', TOPUP_ONLY)).toBe('cards');
+		expect(resolveCapabilityRedirect('disabled', SALES_ONLY)).toBe('events');
+	});
+});
+
+describe('getDeviceCapabilities', () => {
+
+	afterEach(() => {
+		delete globalThis.window;
+	});
+
+	it('defaults to fully enabled when flags are missing', () => {
+		globalThis.window = {};
+		expect(getDeviceCapabilities()).toEqual({ allowSales: true, allowTopup: true });
+	});
+
+	it('reads explicit false flags', () => {
+		globalThis.window = { DEVICE_ALLOW_SALES: false, DEVICE_ALLOW_TOPUP: false };
+		expect(getDeviceCapabilities()).toEqual({ allowSales: false, allowTopup: false });
+	});
+});
+
+describe('POS app wiring', () => {
+	const source = readFileSync(resolve(__dirname, '..', 'pos', 'js', 'app.js'), 'utf-8');
+
+	it('sets window capability flags from device data', () => {
+		expect(source).toContain('window.DEVICE_ALLOW_SALES');
+		expect(source).toContain('window.DEVICE_ALLOW_TOPUP');
+	});
+
+	it('registers the capability guard', () => {
+		expect(source).toContain('resolveCapabilityRedirect');
+		expect(source).toContain('router.beforeEach');
+	});
+
+	it('has the disabled route', () => {
+		expect(source).toContain("name: 'disabled'");
+	});
+});

--- a/tests/Feature/DeviceControllerTest.php
+++ b/tests/Feature/DeviceControllerTest.php
@@ -203,6 +203,17 @@ class DeviceControllerTest extends TestCase
 		]);
 	}
 
+	public function testCapabilityFlagsDefaultToEnabled(): void
+	{
+		$device = Device::factory()->create([
+			'organisation_id' => $this->organisation->id,
+		]);
+
+		$device->refresh();
+		$this->assertTrue($device->allow_sales);
+		$this->assertTrue($device->allow_topup);
+	}
+
 	// ─── Device API: PUT /pos-api/v1/devices/current ───
 
 	public function testUpdateCurrentDevicePublicKey(): void

--- a/tests/Feature/DeviceControllerTest.php
+++ b/tests/Feature/DeviceControllerTest.php
@@ -292,4 +292,59 @@ class DeviceControllerTest extends TestCase
 		// Approval should be reset
 		$this->assertNull($device->fresh()->approved_at);
 	}
+
+	// ─── Capability Flags Tests ───
+
+	public function testCurrentDeviceExposesCapabilityFlags(): void
+	{
+		$this->device->allow_topup = false;
+		$this->device->save();
+
+		$response = $this
+			->withHeader('Authorization', 'Bearer ' . $this->token->access_token)
+			->getJson('/pos-api/v1/devices/current');
+
+		$response->assertStatus(200);
+		$response->assertJsonFragment([
+			'allow_sales' => true,
+			'allow_topup' => false,
+		]);
+	}
+
+	public function testUpdateCurrentDeviceCannotChangeCapabilityFlags(): void
+	{
+		$this->device->allow_topup = false;
+		$this->device->save();
+
+		$response = $this
+			->withHeader('Authorization', 'Bearer ' . $this->token->access_token)
+			->putJson('/pos-api/v1/devices/current', [
+				'allow_topup' => true,
+				'allow_sales' => false,
+			]);
+
+		$response->assertStatus(200);
+
+		$this->device->refresh();
+		// Device API must ignore these fields entirely.
+		$this->assertFalse($this->device->allow_topup);
+		$this->assertTrue($this->device->allow_sales);
+	}
+
+	public function testManagementApiCanUpdateCapabilityFlags(): void
+	{
+		Passport::actingAs($this->user);
+
+		$response = $this->putJson('/api/v1/devices/' . $this->device->id, [
+			'name' => $this->device->name,
+			'allow_sales' => false,
+			'allow_topup' => false,
+		]);
+
+		$response->assertStatus(200);
+
+		$this->device->refresh();
+		$this->assertFalse($this->device->allow_sales);
+		$this->assertFalse($this->device->allow_topup);
+	}
 }

--- a/tests/Feature/OrderAssignmentServiceTest.php
+++ b/tests/Feature/OrderAssignmentServiceTest.php
@@ -232,6 +232,21 @@ class OrderAssignmentServiceTest extends TestCase
 	}
 
 	/**
+	 * Test that assignOrder excludes devices with allow_sales=false.
+	 */
+	public function testAssignOrderExcludesSalesDisabledDevices(): void
+	{
+		$this->createDevice(['name' => 'Topup station', 'allow_sales' => false]);
+		$salesDevice = $this->createDevice(['name' => 'Bar POS']);
+
+		$order = $this->createOrder();
+		$this->service->assignOrder($order);
+
+		$order->refresh();
+		$this->assertEquals($salesDevice->id, $order->assigned_device_id);
+	}
+
+	/**
 	 * Test that assignOrder excludes offline devices (last_ping too old).
 	 */
 	public function testAssignOrderExcludesOfflineDevices(): void
@@ -524,6 +539,25 @@ class OrderAssignmentServiceTest extends TestCase
 
 		$order->refresh();
 		// Should be reassigned — device1 no longer accepts remote orders
+		$this->assertEquals($device2->id, $order->assigned_device_id);
+	}
+
+	/**
+	 * Test that reevaluateAssignments reassigns when device disables sales.
+	 */
+	public function testReevaluateReassignsWhenSalesDisabled(): void
+	{
+		$device1 = $this->createDevice([
+			'name' => 'POS 1',
+			'allow_sales' => false, // just disabled by admin
+		]);
+		$device2 = $this->createDevice(['name' => 'POS 2']);
+
+		$order = $this->createOrder(['assigned_device_id' => $device1->id]);
+
+		$this->service->reevaluateAssignments($this->event, $device1);
+
+		$order->refresh();
 		$this->assertEquals($device2->id, $order->assigned_device_id);
 	}
 

--- a/tests/Feature/TransactionMergerTest.php
+++ b/tests/Feature/TransactionMergerTest.php
@@ -325,6 +325,40 @@ class TransactionMergerTest extends TestCase
 		$this->assertFalse($stored->unauthorized);
 	}
 
+	public function testPositiveSaleFromNonTopupDeviceIsFlagged(): void
+	{
+		$device = Device::factory()->create([
+			'organisation_id' => $this->organisation->id,
+			'allow_topup' => false,
+		]);
+		$card = $this->createCard();
+
+		$merger = new TransactionMerger($this->organisation, $device);
+		$merger->mergeTransactions([
+			$this->makeTransaction($card->uid, 1, 500, 'sale'),
+		]);
+
+		$stored = Transaction::where('card_id', $card->id)->where('card_sync_id', 1)->first();
+		$this->assertTrue($stored->unauthorized);
+	}
+
+	public function testPositiveReversalFromNonTopupDeviceIsNotFlagged(): void
+	{
+		$device = Device::factory()->create([
+			'organisation_id' => $this->organisation->id,
+			'allow_topup' => false,
+		]);
+		$card = $this->createCard();
+
+		$merger = new TransactionMerger($this->organisation, $device);
+		$merger->mergeTransactions([
+			$this->makeTransaction($card->uid, 1, 500, 'reversal'),
+		]);
+
+		$stored = Transaction::where('card_id', $card->id)->where('card_sync_id', 1)->first();
+		$this->assertFalse($stored->unauthorized);
+	}
+
 	public function testMergeEndpointFlagsUnauthorizedTopup(): void
 	{
 		$device = Device::factory()->create([

--- a/tests/Feature/TransactionMergerTest.php
+++ b/tests/Feature/TransactionMergerTest.php
@@ -251,4 +251,114 @@ class TransactionMergerTest extends TestCase
 
 		$response->assertStatus(200);
 	}
+
+	public function testMergeRecordsUploadingDevice(): void
+	{
+		$device = Device::factory()->create([
+			'organisation_id' => $this->organisation->id,
+		]);
+		// allow_topup has a DB-level default (true) that isn't hydrated onto the
+		// in-memory model after INSERT on MySQL; refresh to observe the real value,
+		// matching the pattern used in DeviceControllerTest::testCapabilityFlagsDefaultToEnabled.
+		$device->refresh();
+		$card = $this->createCard();
+
+		$merger = new TransactionMerger($this->organisation, $device);
+		$merger->mergeTransactions([
+			$this->makeTransaction($card->uid, 1, 500, 'topup'),
+		]);
+
+		$stored = Transaction::where('card_id', $card->id)->where('card_sync_id', 1)->first();
+		$this->assertEquals($device->id, $stored->uploaded_by_device_id);
+		$this->assertFalse($stored->unauthorized);
+	}
+
+	public function testTopupFromNonTopupDeviceIsFlagged(): void
+	{
+		$device = Device::factory()->create([
+			'organisation_id' => $this->organisation->id,
+			'allow_topup' => false,
+		]);
+		$card = $this->createCard();
+
+		$merger = new TransactionMerger($this->organisation, $device);
+		$merger->mergeTransactions([
+			$this->makeTransaction($card->uid, 1, 500, 'topup'),
+			$this->makeTransaction($card->uid, 2, -200, 'sale'),
+		]);
+
+		$topup = Transaction::where('card_id', $card->id)->where('card_sync_id', 1)->first();
+		$sale = Transaction::where('card_id', $card->id)->where('card_sync_id', 2)->first();
+		$this->assertTrue($topup->unauthorized);
+		$this->assertFalse($sale->unauthorized);
+	}
+
+	public function testResetAndRefundFromNonTopupDeviceAreFlagged(): void
+	{
+		$device = Device::factory()->create([
+			'organisation_id' => $this->organisation->id,
+			'allow_topup' => false,
+		]);
+		$card = $this->createCard();
+
+		$merger = new TransactionMerger($this->organisation, $device);
+		$merger->mergeTransactions([
+			$this->makeTransaction($card->uid, 1, 500, 'reset'),
+			$this->makeTransaction($card->uid, 2, -100, 'refund'),
+		]);
+
+		$this->assertTrue(Transaction::where('card_id', $card->id)->where('card_sync_id', 1)->first()->unauthorized);
+		$this->assertTrue(Transaction::where('card_id', $card->id)->where('card_sync_id', 2)->first()->unauthorized);
+	}
+
+	public function testMergeWithoutDeviceDoesNotFlag(): void
+	{
+		$card = $this->createCard();
+
+		$merger = new TransactionMerger($this->organisation);
+		$merger->mergeTransactions([
+			$this->makeTransaction($card->uid, 1, 500, 'topup'),
+		]);
+
+		$stored = Transaction::where('card_id', $card->id)->where('card_sync_id', 1)->first();
+		$this->assertNull($stored->uploaded_by_device_id);
+		$this->assertFalse($stored->unauthorized);
+	}
+
+	public function testMergeEndpointFlagsUnauthorizedTopup(): void
+	{
+		$device = Device::factory()->create([
+			'organisation_id' => $this->organisation->id,
+			'allow_topup' => false,
+		]);
+		$card = $this->createCard('card-unauth-001');
+
+		$token = new DeviceAccessToken([
+			'device_id' => $device->id,
+			'access_token' => 'unauth-test-token',
+			'expires_at' => now()->addHour(),
+		]);
+		$token->created_by = $this->user->id;
+		$token->save();
+
+		$response = $this
+			->withHeader('Authorization', 'Bearer ' . $token->access_token)
+			->postJson('/pos-api/v1/organisations/' . $this->organisation->id . '/merge-transactions', [
+				'items' => [
+					[
+						'card' => 'card-unauth-001',
+						'card_transaction' => 1,
+						'value' => 500,
+						'type' => 'topup',
+						'has_synced' => true,
+					],
+				],
+			]);
+
+		$response->assertStatus(200);
+
+		$stored = Transaction::where('card_id', $card->id)->where('card_sync_id', 1)->first();
+		$this->assertTrue($stored->unauthorized);
+		$this->assertEquals($device->id, $stored->uploaded_by_device_id);
+	}
 }


### PR DESCRIPTION
## Summary

Implements the feature request to assign POS devices a limited function — **sales-only, topup-only, or both** — so bar volunteers cannot top up or reset NFC cards, while dedicated topup stations can be locked out of sales.

- Two admin-controlled flags on `Device`: `allow_sales` / `allow_topup` (default `true`, existing fleets unaffected). Editable only via the Management API (Manage → Devices → Edit, with capability badges in the list); the Device API exposes them **read-only**, so a device cannot re-enable its own capabilities.
- POS gates its UI and routes by the flags (router guard covers deep links; nav items hidden; order toggles hidden; topup/reset/rebuild/discount/alias controls in the shared Card component gated; a "no functions enabled" screen when both flags are off, with Settings always reachable).
- Because card balances are written offline with the device's signing key, rogue topups cannot be rejected server-side. Instead the transaction merger records `uploaded_by_device_id` on every device upload and marks `unauthorized = true` for topup/reset/refund uploads — and any positive-value non-reversal upload — from non-topup devices. Flagged rows get a red badge in the transactions overview. Residual risks are documented in the spec's Known limitations section.
- Sales-disabled devices are excluded from remote-order assignment (mirrors `allow_remote_orders`), and pending orders are reassigned when an admin disables sales.
- Includes the dockerized PHPUnit runner (`docker compose run --rm phpunit`, `test` profile) mirroring CI.

Design spec: `docs/superpowers/specs/2026-07-08-device-capability-flags-design.md`

## Test plan

- PHPUnit: 208 passing (12 new: capability defaults, Device API read-only boundary, Management write path, merger flagging incl. positive-value rule and endpoint-level HTTP test, order-assignment exclusion)
- Vitest: 184 passing (16 new: capability redirect matrix, boot/guard wiring, Card topup-UI gating)
- Jest (NFC): 32 passing — card format and signing untouched
- `npm run production` builds clean; i18n keys verified identical across all 5 locales
- Not covered automatically: end-to-end check with a physical paired device + NFC hardware (manual checklist in the plan, step 10.4) — the server-side upload path is covered by an HTTP-level test with a real device token

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RQjdQhQM3q7MZCWCv3AdmD