### PR TITLE
SSO account deeplink + test-mode license purchase warning

### DIFF
--- a/app/Http/Controllers/AccountLinkController.php
+++ b/app/Http/Controllers/AccountLinkController.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * CatLab Drinks - Simple bar automation system
+ * Copyright (C) 2019 Thijs Van der Schaeghe
+ * CatLab Interactive bvba, Gent, Belgium
+ * http://www.catlab.eu/
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+namespace App\Http\Controllers;
+
+use CatLab\Accounts\Client\ApiClient;
+
+/**
+ * Deep-links SSO users to their CatLab accounts page (change password,
+ * email, billing) via the accounts authcode login mechanism.
+ *
+ * Note: services.catlab.url is expected to carry its default trailing
+ * slash (config/services.php), so the path is passed without one.
+ */
+class AccountLinkController
+{
+    public function redirect()
+    {
+        $user = \Auth::user();
+
+        if (!config('services.catlab.client_id')
+            || !$user
+            || $user->catlab_id === null
+            || empty($user->catlab_access_token)) {
+            return redirect('/manage');
+        }
+
+        return redirect((new ApiClient($user))->getAccountLink('myaccount'));
+    }
+}

--- a/docs/superpowers/plans/2026-08-04-sso-account-deeplink.md
+++ b/docs/superpowers/plans/2026-08-04-sso-account-deeplink.md
@@ -1,0 +1,244 @@
+# SSO Account Deeplink Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A "My CatLab Account" item in the Manage navbar that deep-links SSO users to their accounts `/myaccount` page, auto-authenticated via the vendor `getAccountLink` mechanism.
+
+**Architecture:** A `GET /account` route redirects SSO users to `{accounts}/myaccount?authcode={token}` (built by the vendored `CatLab\Accounts\Client\ApiClient`) and everyone else to `/manage`. The blade exposes an `SSO_ACCOUNT` boolean; the navbar renders the item only when it's true.
+
+**Tech Stack:** Laravel 9, vendored `catlabinteractive/laravel-catlab-accounts`, Vue 3 compat + Bootstrap-Vue.
+
+**Spec:** `docs/superpowers/specs/2026-08-04-sso-account-deeplink-design.md`.
+
+## Global Constraints
+
+- Branch: `feature/sso-account-deeplink` (stacked on `feature/profiles-organisations-sync`, already checked out).
+- PHP tests: `vendor/bin/phpunit --filter <Class>`; falls back to `docker compose --profile test run --rm phpunit --filter <Class>` if the host has no PHP.
+- "Logged in through SSO" = `config('services.catlab.client_id')` set **and** the user's `catlab_id` is non-null; the redirect additionally requires a non-empty `catlab_access_token`.
+- The vendor builds `Config::get('services.catlab.url') . $path`. The config URL carries a trailing slash by default (`https://accounts.catlab.eu/` in `config/services.php`), so the controller calls `getAccountLink('myaccount')` — path without a leading slash — and its docblock documents the trailing-slash expectation. Tests set the config URL with the trailing slash to match.
+- Vue/JS files use tabs; PHP app files use 4 spaces; GPL headers on new files.
+- Never commit `package-lock.json`.
+
+---
+
+### Task 1: `GET /account` redirect + navbar item + i18n
+
+**Files:**
+- Create: `app/Http/Controllers/AccountLinkController.php`
+- Modify: `routes/web.php` (add route), `resources/views/client/manage.blade.php` (add `SSO_ACCOUNT` flag), `resources/manage/js/views/App.vue` (Settings dropdown item + data flag), `resources/shared/js/i18n/nl.js`, `resources/shared/js/i18n/fr.js`, `resources/shared/js/i18n/de.js`, `resources/shared/js/i18n/es.js`, `resources/shared/js/i18n/en.js` (only if it enumerates all keys — check)
+- Test: `tests/Feature/AccountLinkTest.php` (new)
+
+**Interfaces:**
+- Consumes: vendored `CatLab\Accounts\Client\ApiClient::__construct($user)` + `getAccountLink(string $path, array $parameters = []): string`; `users.catlab_id`, `users.catlab_access_token`; blade global pattern `window.CATLAB_DRINKS_CONFIG.*`.
+- Produces: route `GET /account` (auth); blade global `window.CATLAB_DRINKS_CONFIG.SSO_ACCOUNT` (boolean).
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/Feature/AccountLinkTest.php` (GPL header copied from another test file):
+
+```php
+<?php
+/* (GPL header) */
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+/**
+ * Tests the SSO account deeplink redirect (GET /account).
+ */
+class AccountLinkTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        config([
+            'services.catlab.url' => 'https://accounts.test/',
+            'services.catlab.client_id' => 'test-client',
+        ]);
+    }
+
+    private function makeUser(): User
+    {
+        return User::query()->create([
+            'name' => 'Test User',
+            'email' => 'test-' . Str::random(8) . '@example.com',
+            'password' => bcrypt('secret'),
+        ]);
+    }
+
+    public function testSsoUserIsRedirectedToAccountsWithAuthcode(): void
+    {
+        $user = $this->makeUser();
+        $user->catlab_id = 4242;
+        $user->catlab_access_token = 'token-4242';
+        $user->save();
+
+        $response = $this->actingAs($user->fresh())->get('/account');
+
+        $response->assertRedirect('https://accounts.test/myaccount?authcode=token-4242');
+    }
+
+    public function testLocalUserIsRedirectedToManage(): void
+    {
+        $user = $this->makeUser();
+
+        $response = $this->actingAs($user)->get('/account');
+
+        $response->assertRedirect('/manage');
+    }
+
+    public function testSsoUserWithoutTokenIsRedirectedToManage(): void
+    {
+        $user = $this->makeUser();
+        $user->catlab_id = 4243;
+        $user->save();
+
+        $response = $this->actingAs($user->fresh())->get('/account');
+
+        $response->assertRedirect('/manage');
+    }
+
+    public function testNonSsoInstanceRedirectsToManage(): void
+    {
+        config(['services.catlab.client_id' => null]);
+        $user = $this->makeUser();
+        $user->catlab_id = 4244;
+        $user->catlab_access_token = 'token-4244';
+        $user->save();
+
+        $response = $this->actingAs($user->fresh())->get('/account');
+
+        $response->assertRedirect('/manage');
+    }
+
+    public function testGuestIsRedirectedToLogin(): void
+    {
+        $response = $this->get('/account');
+
+        $response->assertStatus(302);
+        $this->assertGuest();
+    }
+}
+```
+
+Note on the expected URL: the config URL carries a trailing slash by convention
+(`config/services.php` default is `https://accounts.catlab.eu/`), and the controller
+passes the path without a leading slash, so the result has exactly one slash.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `vendor/bin/phpunit --filter AccountLinkTest`
+Expected: FAIL — `/account` returns 404 (route missing).
+
+- [ ] **Step 3: Implement controller + route**
+
+Create `app/Http/Controllers/AccountLinkController.php`:
+
+```php
+<?php
+/* (GPL header) */
+
+namespace App\Http\Controllers;
+
+use CatLab\Accounts\Client\ApiClient;
+
+/**
+ * Deep-links SSO users to their CatLab accounts page (change password,
+ * email, billing) via the accounts authcode login mechanism.
+ *
+ * Note: services.catlab.url is expected to carry its default trailing
+ * slash (config/services.php), so the path is passed without one.
+ */
+class AccountLinkController
+{
+    public function redirect()
+    {
+        $user = \Auth::user();
+
+        if (!config('services.catlab.client_id')
+            || !$user
+            || $user->catlab_id === null
+            || empty($user->catlab_access_token)) {
+            return redirect('/manage');
+        }
+
+        return redirect((new ApiClient($user))->getAccountLink('myaccount'));
+    }
+}
+```
+
+In `routes/web.php`, next to the license-return route (before the `/manage/{any?}` catch-all is fine anywhere — the path doesn't collide):
+
+```php
+/*
+ * Deeplink to the CatLab accounts "my account" page (SSO users only).
+ */
+Route::get('/account', 'AccountLinkController@redirect')
+    ->middleware('auth');
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `vendor/bin/phpunit --filter AccountLinkTest`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Blade flag**
+
+In `resources/views/client/manage.blade.php`, extend the existing inline script block with one line after the `ACCOUNTS_URL` assignment:
+
+```html
+    window.CATLAB_DRINKS_CONFIG.SSO_ACCOUNT = @json((bool)(config('services.catlab.client_id') && \Auth::user() && \Auth::user()->catlab_id !== null));
+```
+
+- [ ] **Step 6: Navbar item**
+
+In `resources/manage/js/views/App.vue` (tabs), inside the Settings dropdown, add a first item above "Organisation Settings":
+
+```html
+						<b-nav-item-dropdown :text="$t('Settings')" right>
+							<b-dropdown-item v-if="ssoAccount" href="/account" target="_blank" rel="noopener">{{ $t('My CatLab Account') }}</b-dropdown-item>
+							<b-dropdown-item :to="{ name: 'settings' }">{{ $t('Organisation Settings') }}</b-dropdown-item>
+							<b-dropdown-item :to="{ name: 'publicKeys' }">{{ $t('Public Keys') }}</b-dropdown-item>
+						</b-nav-item-dropdown>
+```
+
+and add to the component's `data()` return object:
+
+```js
+				ssoAccount: !!(window.CATLAB_DRINKS_CONFIG && window.CATLAB_DRINKS_CONFIG.SSO_ACCOUNT),
+```
+
+- [ ] **Step 7: i18n**
+
+Add the `'My CatLab Account'` key to each locale file that enumerates all keys, next to the existing `'Rename on CatLab Accounts'` entry (nl.js line ~385):
+
+- nl: `'My CatLab Account': 'Mijn CatLab account',`
+- fr: `'My CatLab Account': 'Mon compte CatLab',`
+- de: `'My CatLab Account': 'Mein CatLab-Konto',`
+- es: `'My CatLab Account': 'Mi cuenta de CatLab',`
+- en: `'My CatLab Account': 'My CatLab Account',` (only if en.js enumerates all keys — follow whatever `'Rename on CatLab Accounts'` did there)
+
+- [ ] **Step 8: Build + full suites**
+
+```bash
+npm run dev
+npx vitest run
+npx jest
+vendor/bin/phpunit
+git checkout -- package-lock.json
+```
+
+Expected: build succeeds, all suites green (287 PHP tests: 282 + 5 new).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add app/Http/Controllers/AccountLinkController.php routes/web.php resources/views/client/manage.blade.php resources/manage/js/views/App.vue resources/shared/js/i18n/ tests/Feature/AccountLinkTest.php
+git commit -m "Add SSO account deeplink to the Manage menu"
+```

--- a/docs/superpowers/plans/2026-08-04-test-mode-license-purchase-warning.md
+++ b/docs/superpowers/plans/2026-08-04-test-mode-license-purchase-warning.md
@@ -1,0 +1,158 @@
+# Test-Mode License Purchase Warning Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Show a warning modal before navigating to the license shop when the current organisation is in testing mode on a shared instance.
+
+**Architecture:** Frontend-only change in the Manage Devices view: the "Buy License" dropdown item switches from a direct `href` to a click handler that checks `window.ORGANISATION_TEST_MODE` — false navigates immediately (unchanged behaviour), true opens a Bootstrap-Vue confirmation modal whose "Continue to purchase" button performs the same navigation.
+
+**Tech Stack:** Vue 3 compat + Bootstrap-Vue (`b-modal`), vue-i18n.
+
+**Spec:** `docs/superpowers/specs/2026-08-04-test-mode-license-purchase-warning-design.md`.
+
+## Global Constraints
+
+- Branch: `feature/sso-account-deeplink` (already checked out; this rides in PR #191).
+- `resources/manage/js/views/Devices.vue` and the i18n files use TABS.
+- `window.ORGANISATION_TEST_MODE` is set at Manage boot; treat it as the sole test-mode signal. No backend changes.
+- Same-tab navigation (`window.location.href`), matching the current `href` behaviour.
+- Existing i18n keys reused: `'Cancel'`; the link label `'How to set up your own instance'` exists as a `$t()` key in `App.vue` but has NO entry in any locale file (falls back to key text) — do not add it.
+- No new JS unit tests (spec decision): verification is `npm run dev` + existing suites green.
+- Never commit `package-lock.json`.
+
+---
+
+### Task 1: Warning modal in Devices.vue + i18n
+
+**Files:**
+- Modify: `resources/manage/js/views/Devices.vue` (dropdown item ~line 103, template modals ~line 218-235, `data()` ~line 314-322, `methods` near `buyLicenseUrl` ~line 420), `resources/shared/js/i18n/nl.js`, `resources/shared/js/i18n/fr.js`, `resources/shared/js/i18n/de.js`, `resources/shared/js/i18n/es.js`, `resources/shared/js/i18n/en.js`
+- Test: none new (build + existing suites)
+
+**Interfaces:**
+- Consumes: `window.ORGANISATION_TEST_MODE` (boot global), existing `buyLicenseUrl(device): string` method, existing modal pattern (`ref` + `this.$refs.x.show()/hide()`).
+- Produces: nothing consumed elsewhere.
+
+- [ ] **Step 1: Change the dropdown item**
+
+In `resources/manage/js/views/Devices.vue` (~line 103), replace:
+
+```html
+							<b-dropdown-item :href="buyLicenseUrl(row.item)" :title="$t('Buy License')">
+								🔑
+								{{ $t('Buy License') }}
+							</b-dropdown-item>
+```
+
+with:
+
+```html
+							<b-dropdown-item @click="buyLicense(row.item)" :title="$t('Buy License')">
+								🔑
+								{{ $t('Buy License') }}
+							</b-dropdown-item>
+```
+
+- [ ] **Step 2: Add the warning modal to the template**
+
+Directly after the closing `</b-modal>` of the "Enter license modal" (before `<signed-cards-modal ref="signedCardsModal" />`), add:
+
+```html
+	<!-- Test-mode license purchase warning -->
+	<b-modal :title="$t('Testing mode')" ref="buyLicenseWarningModal">
+
+		<p>
+			{{ $t('Your organisation is using this shared instance in testing mode. You can buy a license and it will work here, but for production events we recommend setting up your own instance.') }}
+			<a href="https://github.com/CatLabInteractive/catlab-drinks#run-your-own-instance" target="_blank" rel="noopener">{{ $t('How to set up your own instance') }}</a>
+		</p>
+		<p>{{ $t('Are you sure you want to continue to the license purchase?') }}</p>
+
+		<template #modal-footer>
+			<b-btn type="button" variant="light" @click="$refs.buyLicenseWarningModal.hide()">{{ $t('Cancel') }}</b-btn>
+			<b-btn type="button" variant="warning" @click="confirmBuyLicense()">
+				<span class="mr-1">🔑</span> {{ $t('Continue to purchase') }}
+			</b-btn>
+		</template>
+	</b-modal>
+```
+
+- [ ] **Step 3: Add state + methods**
+
+In `data()`, after `licenseError: null` add (mind the comma on the previous line):
+
+```js
+				buyLicenseDevice: null
+```
+
+In `methods`, directly after the `buyLicenseUrl(device)` method, add:
+
+```js
+			buyLicense(device) {
+				if (!window.ORGANISATION_TEST_MODE) {
+					window.location.href = this.buyLicenseUrl(device);
+					return;
+				}
+
+				this.buyLicenseDevice = device;
+				this.$refs.buyLicenseWarningModal.show();
+			},
+
+			confirmBuyLicense() {
+				window.location.href = this.buyLicenseUrl(this.buyLicenseDevice);
+			},
+```
+
+- [ ] **Step 4: i18n**
+
+Add these four keys to each of nl/fr/de/es/en (`resources/shared/js/i18n/*.js`), next to the `'Rename on CatLab Accounts'` entry, matching each file's quoting/tab style. en.js maps them to themselves (its convention); translations:
+
+nl:
+```js
+	'Testing mode': 'Testmodus',
+	'Your organisation is using this shared instance in testing mode. You can buy a license and it will work here, but for production events we recommend setting up your own instance.': 'Jouw organisatie gebruikt deze gedeelde omgeving in testmodus. Je kan een licentie kopen en die zal hier werken, maar voor productie-evenementen raden we aan een eigen omgeving op te zetten.',
+	'Are you sure you want to continue to the license purchase?': 'Ben je zeker dat je wil doorgaan naar de licentie-aankoop?',
+	'Continue to purchase': 'Doorgaan naar aankoop',
+```
+
+fr:
+```js
+	'Testing mode': 'Mode test',
+	'Your organisation is using this shared instance in testing mode. You can buy a license and it will work here, but for production events we recommend setting up your own instance.': 'Votre organisation utilise cette instance partagée en mode test. Vous pouvez acheter une licence et elle fonctionnera ici, mais pour des événements en production nous recommandons de mettre en place votre propre instance.',
+	'Are you sure you want to continue to the license purchase?': 'Voulez-vous vraiment continuer vers l\'achat de licence ?',
+	'Continue to purchase': 'Continuer vers l\'achat',
+```
+
+de:
+```js
+	'Testing mode': 'Testmodus',
+	'Your organisation is using this shared instance in testing mode. You can buy a license and it will work here, but for production events we recommend setting up your own instance.': 'Deine Organisation nutzt diese geteilte Instanz im Testmodus. Du kannst eine Lizenz kaufen und sie wird hier funktionieren, aber für Produktionsveranstaltungen empfehlen wir eine eigene Instanz.',
+	'Are you sure you want to continue to the license purchase?': 'Möchtest du wirklich mit dem Lizenzkauf fortfahren?',
+	'Continue to purchase': 'Weiter zum Kauf',
+```
+
+es:
+```js
+	'Testing mode': 'Modo de prueba',
+	'Your organisation is using this shared instance in testing mode. You can buy a license and it will work here, but for production events we recommend setting up your own instance.': 'Tu organización está usando esta instancia compartida en modo de prueba. Puedes comprar una licencia y funcionará aquí, pero para eventos en producción recomendamos configurar tu propia instancia.',
+	'Are you sure you want to continue to the license purchase?': '¿Seguro que quieres continuar con la compra de la licencia?',
+	'Continue to purchase': 'Continuar con la compra',
+```
+
+If a file's existing long strings use different escaping conventions (e.g. double quotes), match the file.
+
+- [ ] **Step 5: Build + suites**
+
+```bash
+npm run dev
+npx vitest run
+npx jest
+git checkout -- package-lock.json
+```
+
+Expected: build succeeds; vitest 188, jest 32 green (no PHP changes — skip phpunit).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add resources/manage/js/views/Devices.vue resources/shared/js/i18n/
+git commit -m "Warn before license purchase when organisation is in testing mode"
+```

--- a/docs/superpowers/specs/2026-08-04-sso-account-deeplink-design.md
+++ b/docs/superpowers/specs/2026-08-04-sso-account-deeplink-design.md
@@ -1,0 +1,74 @@
+# SSO account deeplink in the Manage menu
+
+**Date:** 2026-08-04
+**Status:** Approved
+
+## Background
+
+SSO users manage their credentials (password, email, billing) on the CatLab accounts
+server, not in drinks. The accounts server exposes a user-facing `/myaccount` page and
+supports one-shot login via an `authcode` query parameter (an accounts access token; the
+server consumes it, starts a session, and strips the parameter — `catlab-accounts
+src/Accounts/Module.php:184-207`). The already-vendored
+`CatLab\Accounts\Client\ApiClient::getAccountLink($path, $parameters = [])` builds
+exactly such links: `{services.catlab.url}{path}?authcode={catlab_access_token}` —
+currently unused in drinks.
+
+Manage's navbar (`resources/manage/js/views/App.vue`) has a Settings dropdown; the blade
+(`resources/views/client/manage.blade.php`) already injects per-request globals
+(`ORGANISATION_ID`, `CATLAB_DRINKS_CONFIG.ACCOUNTS_URL`).
+
+## Requirement
+
+A "My CatLab Account" menu item in the Manage navbar that deep-links the user to their
+accounts `/myaccount` page, already authenticated — shown **only** when the user logged
+in through SSO.
+
+"Logged in through SSO" = `config('services.catlab.client_id')` is set (SSO instance)
+**and** the authenticated user has a non-null `catlab_id`. (Both conditions matter: a
+founding local user can exist on an instance later configured for SSO.)
+
+## Design
+
+### Backend: `GET /account`
+
+- Route in `routes/web.php` behind the `auth` middleware; controller
+  `App\Http\Controllers\AccountLinkController@redirect`.
+- SSO user (per the definition above, and with a non-empty `catlab_access_token`):
+  `return redirect((new \CatLab\Accounts\Client\ApiClient($user))->getAccountLink('/myaccount'));`
+- Anyone else (local user, SSO-configured instance without a linked account, missing
+  token): `return redirect('/manage');`
+- No HTTP call is involved — `getAccountLink` is pure URL building. The token appears
+  once in the redirect URL; the accounts server consumes and strips it. The SPA never
+  sees the token.
+
+### Frontend: navbar item
+
+- In `App.vue`'s Settings dropdown, above "Organisation Settings":
+  a `b-dropdown-item` with `href="/account"`, `target="_blank"`, `rel="noopener"`,
+  label `{{ $t('My CatLab Account') }}`, rendered only when
+  `window.CATLAB_DRINKS_CONFIG.SSO_ACCOUNT` is truthy (captured into component data).
+- `manage.blade.php` sets the flag next to `ACCOUNTS_URL`:
+  `window.CATLAB_DRINKS_CONFIG.SSO_ACCOUNT = @json((bool)(config('services.catlab.client_id') && \Auth::user() && \Auth::user()->catlab_id !== null));`
+
+### i18n
+
+`'My CatLab Account'` key added to the locale files following their convention
+(nl: `'Mijn CatLab account'`; fr/de/es analogous since those files enumerate all keys).
+
+## Testing
+
+Feature test `AccountLinkTest`:
+- SSO user (client_id configured, `catlab_id` + `catlab_access_token` set) → 302 to
+  `{accounts-url}/myaccount?authcode={token}`.
+- Local user (no `catlab_id`) → 302 to `/manage`.
+- SSO-linked user without a stored token → 302 to `/manage`.
+- Guest → redirected to login (default `auth` behaviour).
+
+No new JS tests: the frontend change is a template conditional on a boot global.
+
+## Out of scope
+
+- No return-link from accounts back to drinks (accounts `/myaccount` has no `return`
+  support worth wiring here).
+- POS app untouched; non-SSO instances see no change.

--- a/docs/superpowers/specs/2026-08-04-test-mode-license-purchase-warning-design.md
+++ b/docs/superpowers/specs/2026-08-04-test-mode-license-purchase-warning-design.md
@@ -1,0 +1,53 @@
+# Test-mode warning before license purchase
+
+**Date:** 2026-08-04
+**Status:** Approved
+
+## Background
+
+On a shared instance, organisations not listed in `PRODUCTION_ORGANISATION_IDS` run in
+testing mode (`Organisation::getTestModeAttribute()`); the Manage SPA receives this as
+`window.ORGANISATION_TEST_MODE` at boot (false on private instances, whose whitelist is
+empty). The Manage Devices view's "Buy License" action
+(`resources/manage/js/views/Devices.vue:103`) is a plain `href` that navigates directly
+to the accounts license shop (`buyLicenseUrl()`, line ~420).
+
+## Requirement
+
+When the current organisation is in testing mode, clicking "Buy License" shows a warning
+modal before navigating to the purchase page. Production-mode organisations keep the
+current direct navigation. Purchasing stays allowed either way — this is a warning, not
+a block. No backend changes.
+
+## Design
+
+All changes in `resources/manage/js/views/Devices.vue` (+ i18n files):
+
+- The "Buy License" dropdown item becomes `@click="buyLicense(row.item)"` (drop the
+  `:href`).
+- `buyLicense(device)`: if `!window.ORGANISATION_TEST_MODE` → `window.location.href =
+  this.buyLicenseUrl(device)` (same-tab, as today). Else stow the device in
+  `buyLicenseDevice` and show the warning modal (`ref="buyLicenseWarningModal"`).
+- New `b-modal` titled `$t('Testing mode')` with body:
+  - `$t('Your organisation is using this shared instance in testing mode. You can buy a license and it will work here, but for production events we recommend setting up your own instance.')`
+  - a link to `https://github.com/CatLabInteractive/catlab-drinks#run-your-own-instance`
+    labelled with the existing key `$t('How to set up your own instance')` (target
+    `_blank`, `rel="noopener"`).
+  - `$t('Are you sure you want to continue to the license purchase?')`
+  - Footer: cancel button (`$t('Cancel')`, existing key) hides the modal;
+    `$t('Continue to purchase')` navigates to `buyLicenseUrl(buyLicenseDevice)`.
+- New i18n keys (added to all five locale files, which enumerate every key):
+  `'Testing mode'`, the warning sentence, the confirmation sentence,
+  `'Continue to purchase'`. `'How to set up your own instance'` and `'Cancel'` exist.
+
+## Testing
+
+No new JS unit tests: this is view-glue in a component with no component-test harness,
+and extracting a one-line boolean check into a module for testability is not worth it.
+Verification = `npm run dev` build + existing suites stay green (vitest, jest, phpunit
+untouched).
+
+## Out of scope
+
+- Backend enforcement or purchase blocking.
+- POS app, private instances, the Enter License flow (manual paste stays untouched).

--- a/resources/manage/js/views/App.vue
+++ b/resources/manage/js/views/App.vue
@@ -51,6 +51,7 @@
 						</b-nav-item-dropdown>
 
 						<b-nav-item-dropdown :text="$t('Settings')" right>
+							<b-dropdown-item v-if="ssoAccount" href="/account" target="_blank" rel="noopener">{{ $t('My CatLab Account') }}</b-dropdown-item>
 							<b-dropdown-item :to="{ name: 'settings' }">{{ $t('Organisation Settings') }}</b-dropdown-item>
 							<b-dropdown-item :to="{ name: 'publicKeys' }">{{ $t('Public Keys') }}</b-dropdown-item>
 						</b-nav-item-dropdown>
@@ -94,7 +95,8 @@
 				kioskMode: false,
 				testMode: !!window.ORGANISATION_TEST_MODE,
 				organisations: window.ORGANISATIONS || [],
-				currentOrganisationId: window.ORGANISATION_ID
+				currentOrganisationId: window.ORGANISATION_ID,
+				ssoAccount: !!(window.CATLAB_DRINKS_CONFIG && window.CATLAB_DRINKS_CONFIG.SSO_ACCOUNT)
 			}
 		},
 

--- a/resources/manage/js/views/Devices.vue
+++ b/resources/manage/js/views/Devices.vue
@@ -100,7 +100,7 @@
 								{{ $t('Edit') }}
 							</b-dropdown-item>
 
-							<b-dropdown-item :href="buyLicenseUrl(row.item)" :title="$t('Buy License')">
+							<b-dropdown-item @click="buyLicense(row.item)" :title="$t('Buy License')">
 								🔑
 								{{ $t('Buy License') }}
 							</b-dropdown-item>
@@ -234,6 +234,23 @@
 		</template>
 	</b-modal>
 
+	<!-- Test-mode license purchase warning -->
+	<b-modal :title="$t('Testing mode')" ref="buyLicenseWarningModal">
+
+		<p>
+			{{ $t('Your organisation is using this shared instance in testing mode. You can buy a license and it will work here, but for production events we recommend setting up your own instance.') }}
+			<a href="https://github.com/CatLabInteractive/catlab-drinks#run-your-own-instance" target="_blank" rel="noopener">{{ $t('How to set up your own instance') }}</a>
+		</p>
+		<p>{{ $t('Are you sure you want to continue to the license purchase?') }}</p>
+
+		<template #modal-footer>
+			<b-btn type="button" variant="light" @click="$refs.buyLicenseWarningModal.hide()">{{ $t('Cancel') }}</b-btn>
+			<b-btn type="button" variant="warning" @click="confirmBuyLicense()">
+				<span class="mr-1">🔑</span> {{ $t('Continue to purchase') }}
+			</b-btn>
+		</template>
+	</b-modal>
+
 	<signed-cards-modal ref="signedCardsModal" />
 
 </template>
@@ -318,7 +335,8 @@
 				editModel: {},
 				licenseDevice: null,
 				licenseKey: null,
-				licenseError: null
+				licenseError: null,
+				buyLicenseDevice: null
 			}
 		},
 
@@ -420,6 +438,20 @@
 			buyLicenseUrl(device) {
 				const returnUrl = window.location.origin + '/manage/devices/apply-license?device_id=' + encodeURIComponent(device.id);
 				return 'https://accounts.catlab.eu/licenses/10/buy?data[device_uid]=' + encodeURIComponent(device.uid) + '&return=' + encodeURIComponent(returnUrl);
+			},
+
+			buyLicense(device) {
+				if (!window.ORGANISATION_TEST_MODE) {
+					window.location.href = this.buyLicenseUrl(device);
+					return;
+				}
+
+				this.buyLicenseDevice = device;
+				this.$refs.buyLicenseWarningModal.show();
+			},
+
+			confirmBuyLicense() {
+				window.location.href = this.buyLicenseUrl(this.buyLicenseDevice);
 			},
 
 			async handleLicenseReturn() {

--- a/resources/shared/js/i18n/de.js
+++ b/resources/shared/js/i18n/de.js
@@ -383,6 +383,7 @@ export default {
     'Test mode': 'Testmodus',
     'Are you sure you want to remove the {gateway} payment gateway?': 'Sind Sie sicher, dass Sie das {gateway} Zahlungsgateway entfernen möchten?',
     'Rename on CatLab Accounts': 'Auf CatLab Accounts umbenennen',
+    'My CatLab Account': 'Mein CatLab-Konto',
 
     // Client - Order
     'Order': 'Bestellen',

--- a/resources/shared/js/i18n/de.js
+++ b/resources/shared/js/i18n/de.js
@@ -384,6 +384,10 @@ export default {
     'Are you sure you want to remove the {gateway} payment gateway?': 'Sind Sie sicher, dass Sie das {gateway} Zahlungsgateway entfernen möchten?',
     'Rename on CatLab Accounts': 'Auf CatLab Accounts umbenennen',
     'My CatLab Account': 'Mein CatLab-Konto',
+    'Testing mode': 'Testmodus',
+    'Your organisation is using this shared instance in testing mode. You can buy a license and it will work here, but for production events we recommend setting up your own instance.': 'Deine Organisation nutzt diese geteilte Instanz im Testmodus. Du kannst eine Lizenz kaufen und sie wird hier funktionieren, aber für Produktionsveranstaltungen empfehlen wir eine eigene Instanz.',
+    'Are you sure you want to continue to the license purchase?': 'Möchtest du wirklich mit dem Lizenzkauf fortfahren?',
+    'Continue to purchase': 'Weiter zum Kauf',
 
     // Client - Order
     'Order': 'Bestellen',

--- a/resources/shared/js/i18n/en.js
+++ b/resources/shared/js/i18n/en.js
@@ -384,6 +384,7 @@ export default {
     'Test mode': 'Test mode',
     'Are you sure you want to remove the {gateway} payment gateway?': 'Are you sure you want to remove the {gateway} payment gateway?',
     'Rename on CatLab Accounts': 'Rename on CatLab Accounts',
+    'My CatLab Account': 'My CatLab Account',
 
     // Client - Order
     'Order': 'Order',

--- a/resources/shared/js/i18n/en.js
+++ b/resources/shared/js/i18n/en.js
@@ -385,6 +385,10 @@ export default {
     'Are you sure you want to remove the {gateway} payment gateway?': 'Are you sure you want to remove the {gateway} payment gateway?',
     'Rename on CatLab Accounts': 'Rename on CatLab Accounts',
     'My CatLab Account': 'My CatLab Account',
+    'Testing mode': 'Testing mode',
+    'Your organisation is using this shared instance in testing mode. You can buy a license and it will work here, but for production events we recommend setting up your own instance.': 'Your organisation is using this shared instance in testing mode. You can buy a license and it will work here, but for production events we recommend setting up your own instance.',
+    'Are you sure you want to continue to the license purchase?': 'Are you sure you want to continue to the license purchase?',
+    'Continue to purchase': 'Continue to purchase',
 
     // Client - Order
     'Order': 'Order',

--- a/resources/shared/js/i18n/es.js
+++ b/resources/shared/js/i18n/es.js
@@ -384,6 +384,10 @@ export default {
     'Are you sure you want to remove the {gateway} payment gateway?': '¿Está seguro de que desea eliminar la pasarela de pago {gateway}?',
     'Rename on CatLab Accounts': 'Renombrar en CatLab Accounts',
     'My CatLab Account': 'Mi cuenta de CatLab',
+    'Testing mode': 'Modo de prueba',
+    'Your organisation is using this shared instance in testing mode. You can buy a license and it will work here, but for production events we recommend setting up your own instance.': 'Tu organización está usando esta instancia compartida en modo de prueba. Puedes comprar una licencia y funcionará aquí, pero para eventos en producción recomendamos configurar tu propia instancia.',
+    'Are you sure you want to continue to the license purchase?': '¿Seguro que quieres continuar con la compra de la licencia?',
+    'Continue to purchase': 'Continuar con la compra',
 
     // Client - Order
     'Order': 'Pedir',

--- a/resources/shared/js/i18n/es.js
+++ b/resources/shared/js/i18n/es.js
@@ -383,6 +383,7 @@ export default {
     'Test mode': 'Modo de prueba',
     'Are you sure you want to remove the {gateway} payment gateway?': '¿Está seguro de que desea eliminar la pasarela de pago {gateway}?',
     'Rename on CatLab Accounts': 'Renombrar en CatLab Accounts',
+    'My CatLab Account': 'Mi cuenta de CatLab',
 
     // Client - Order
     'Order': 'Pedir',

--- a/resources/shared/js/i18n/fr.js
+++ b/resources/shared/js/i18n/fr.js
@@ -384,6 +384,7 @@ export default {
     'Test mode': 'Mode test',
     'Are you sure you want to remove the {gateway} payment gateway?': 'Êtes-vous sûr de vouloir supprimer la passerelle de paiement {gateway} ?',
     'Rename on CatLab Accounts': 'Renommer sur CatLab Accounts',
+    'My CatLab Account': 'Mon compte CatLab',
 
     // Client - Order
     'Order': 'Commander',

--- a/resources/shared/js/i18n/fr.js
+++ b/resources/shared/js/i18n/fr.js
@@ -385,6 +385,10 @@ export default {
     'Are you sure you want to remove the {gateway} payment gateway?': 'Êtes-vous sûr de vouloir supprimer la passerelle de paiement {gateway} ?',
     'Rename on CatLab Accounts': 'Renommer sur CatLab Accounts',
     'My CatLab Account': 'Mon compte CatLab',
+    'Testing mode': 'Mode test',
+    'Your organisation is using this shared instance in testing mode. You can buy a license and it will work here, but for production events we recommend setting up your own instance.': 'Votre organisation utilise cette instance partagée en mode test. Vous pouvez acheter une licence et elle fonctionnera ici, mais pour des événements en production nous recommandons de mettre en place votre propre instance.',
+    'Are you sure you want to continue to the license purchase?': 'Voulez-vous vraiment continuer vers l\'achat de licence ?',
+    'Continue to purchase': 'Continuer vers l\'achat',
 
     // Client - Order
     'Order': 'Commander',

--- a/resources/shared/js/i18n/nl.js
+++ b/resources/shared/js/i18n/nl.js
@@ -384,6 +384,10 @@ export default {
     'Are you sure you want to remove the {gateway} payment gateway?': 'Weet je zeker dat je de {gateway} betalingsgateway wilt verwijderen?',
     'Rename on CatLab Accounts': 'Naam wijzigen op CatLab Accounts',
     'My CatLab Account': 'Mijn CatLab account',
+    'Testing mode': 'Testmodus',
+    'Your organisation is using this shared instance in testing mode. You can buy a license and it will work here, but for production events we recommend setting up your own instance.': 'Jouw organisatie gebruikt deze gedeelde omgeving in testmodus. Je kan een licentie kopen en die zal hier werken, maar voor productie-evenementen raden we aan een eigen omgeving op te zetten.',
+    'Are you sure you want to continue to the license purchase?': 'Ben je zeker dat je wil doorgaan naar de licentie-aankoop?',
+    'Continue to purchase': 'Doorgaan naar aankoop',
 
     // Client - Order
     'Order': 'Bestellen',

--- a/resources/shared/js/i18n/nl.js
+++ b/resources/shared/js/i18n/nl.js
@@ -383,6 +383,7 @@ export default {
     'Test mode': 'Testmodus',
     'Are you sure you want to remove the {gateway} payment gateway?': 'Weet je zeker dat je de {gateway} betalingsgateway wilt verwijderen?',
     'Rename on CatLab Accounts': 'Naam wijzigen op CatLab Accounts',
+    'My CatLab Account': 'Mijn CatLab account',
 
     // Client - Order
     'Order': 'Bestellen',

--- a/resources/views/client/manage.blade.php
+++ b/resources/views/client/manage.blade.php
@@ -26,6 +26,7 @@
     var ORGANISATION_ID = {{ $organisation ? $organisation->id : 'null' }};
     window.CATLAB_DRINKS_CONFIG = window.CATLAB_DRINKS_CONFIG || {};
     window.CATLAB_DRINKS_CONFIG.ACCOUNTS_URL = @json(rtrim((string)config('services.catlab.url'), '/'));
+    window.CATLAB_DRINKS_CONFIG.SSO_ACCOUNT = @json((bool)(config('services.catlab.client_id') && \Auth::user() && \Auth::user()->catlab_id !== null));
 </script>
 
 <div id="app">

--- a/routes/web.php
+++ b/routes/web.php
@@ -28,6 +28,12 @@ Route::get('/manage/devices/apply-license', 'LicenseController@applyLicense')
     ->middleware('auth');
 
 /*
+ * Deeplink to the CatLab accounts "my account" page (SSO users only).
+ */
+Route::get('/account', 'AccountLinkController@redirect')
+    ->middleware('auth');
+
+/*
  * Link to the single page web application
  */
 Route::get('/manage/{any?}', 'ClientController@manage')

--- a/tests/Feature/AccountLinkTest.php
+++ b/tests/Feature/AccountLinkTest.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * CatLab Drinks - Simple bar automation system
+ * Copyright (C) 2019 Thijs Van der Schaeghe
+ * CatLab Interactive bvba, Gent, Belgium
+ * http://www.catlab.eu/
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+/**
+ * Tests the SSO account deeplink redirect (GET /account).
+ */
+class AccountLinkTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        config([
+            'services.catlab.url' => 'https://accounts.test/',
+            'services.catlab.client_id' => 'test-client',
+        ]);
+    }
+
+    private function makeUser(): User
+    {
+        return User::query()->create([
+            'name' => 'Test User',
+            'email' => 'test-' . Str::random(8) . '@example.com',
+            'password' => bcrypt('secret'),
+        ]);
+    }
+
+    public function testSsoUserIsRedirectedToAccountsWithAuthcode(): void
+    {
+        $user = $this->makeUser();
+        $user->catlab_id = 4242;
+        $user->catlab_access_token = 'token-4242';
+        $user->save();
+
+        $response = $this->actingAs($user->fresh())->get('/account');
+
+        $response->assertRedirect('https://accounts.test/myaccount?authcode=token-4242');
+    }
+
+    public function testLocalUserIsRedirectedToManage(): void
+    {
+        $user = $this->makeUser();
+
+        $response = $this->actingAs($user)->get('/account');
+
+        $response->assertRedirect('/manage');
+    }
+
+    public function testSsoUserWithoutTokenIsRedirectedToManage(): void
+    {
+        $user = $this->makeUser();
+        $user->catlab_id = 4243;
+        $user->save();
+
+        $response = $this->actingAs($user->fresh())->get('/account');
+
+        $response->assertRedirect('/manage');
+    }
+
+    public function testNonSsoInstanceRedirectsToManage(): void
+    {
+        config(['services.catlab.client_id' => null]);
+        $user = $this->makeUser();
+        $user->catlab_id = 4244;
+        $user->catlab_access_token = 'token-4244';
+        $user->save();
+
+        $response = $this->actingAs($user->fresh())->get('/account');
+
+        $response->assertRedirect('/manage');
+    }
+
+    public function testGuestIsRedirectedToLogin(): void
+    {
+        $response = $this->get('/account');
+
+        $response->assertStatus(302);
+        $this->assertGuest();
+    }
+}


### PR DESCRIPTION
## Summary

Stacked on #190. Two small Manage features:

### 1. "My CatLab Account" deeplink (SSO users)

Adds a menu item to the Settings dropdown that deep-links SSO users to the accounts server's `/myaccount` page (change password, email, billing) — already authenticated, via the accounts `authcode` one-shot login that the vendored `ApiClient::getAccountLink()` was built for.

- `GET /account` (auth): SSO users (`client_id` configured + `catlab_id` set + stored token) are redirected to `{accounts}/myaccount?authcode={token}`; accounts consumes and strips the token. Everyone else is redirected to `/manage`. The token never reaches the SPA.
- The manage blade exposes `CATLAB_DRINKS_CONFIG.SSO_ACCOUNT`; the menu item renders only when it's true, opens in a new tab.

Design spec: `docs/superpowers/specs/2026-08-04-sso-account-deeplink-design.md`

### 2. Warning before license purchase in testing mode

On a shared instance, organisations not in `PRODUCTION_ORGANISATION_IDS` run in testing mode. "Buy License" in Manage → Devices now shows a confirmation modal for those organisations before navigating to the license shop (with a pointer to self-hosting docs); production organisations keep the direct navigation. Warning only — purchasing stays allowed. Frontend-only.

Design spec: `docs/superpowers/specs/2026-08-04-test-mode-license-purchase-warning-design.md`

## Test plan

- 5 new feature tests in `AccountLinkTest` (SSO redirect incl. exact authcode URL, local user, tokenless SSO user, non-SSO instance, guest).
- Full suites green: phpunit 287/287, vitest 188/188, jest 32/32; webpack build OK.
- Warning modal is view-glue verified via build + suites (no component-test harness in this app).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TDjpPtRZ5RKiUGhs1DtVFH
