### PR TITLE
Fix service error interceptor crash; move order token behind Actions modal

### DIFF
--- a/docs/superpowers/specs/2026-08-05-order-token-modal-design.md
+++ b/docs/superpowers/specs/2026-08-05-order-token-modal-design.md
@@ -1,0 +1,50 @@
+# Order token modal (Manage Events)
+
+Date: 2026-08-05
+
+## Goal
+
+Stop showing the remote order token as a column in the Manage Events table.
+Instead, expose it via the per-event Actions dropdown, in a modal that also
+explains how the token is used.
+
+## Scope
+
+- **Manage Events view** (`resources/manage/js/views/Events.vue`) only.
+- The POS Events table never rendered the column (no `order_token` entry in
+  `fields`); its leftover `cell(order_token)` template slot and
+  `selectOrderToken` method are removed as dead-code cleanup.
+- No backend changes: `full_order_token` and `order_url` are already exposed
+  on the event resource.
+
+## Changes
+
+1. Remove the `order_token` field from the Manage Events table `fields` array
+   and delete the `cell(order_token)` template slot (including the
+   commented-out legacy block).
+2. Add a dropdown item to the Actions → Sales group, next to
+   "Client order form": `🔑 Remote order token`. Clicking it opens the modal
+   for that event.
+3. New modal (`ref="orderTokenModal"`, OK-only), title
+   "Remote order token" with the event name, containing:
+   - **Order page URL** (`order_url`) in a readonly click-to-select input,
+     labeled as the link to share with customers for remote ordering.
+   - **Full order token** (`full_order_token`) in a readonly click-to-select
+     input.
+   - **Usage notes** (see `.ai/signed-order-urls.md`): the token is
+     `{public}-{secret}`; the public part identifies the event in the order
+     URL, the secret part is used by integrating applications — explicitly
+     naming **QuizWitz** as such a client — to sign order parameters
+     (`card`, `name`) with HMAC-SHA256. The full token must only be shared
+     with trusted integrations.
+4. All user-facing strings go through `$t()`.
+
+## Testing
+
+Extend `resources/tests/events-views.test.js` (existing string-on-template
+pattern):
+
+- Manage template: no `order_token` column field, no `cell(order_token)`
+  slot; has the "Remote order token" action item, the modal, the
+  `full_order_token` input and the QuizWitz mention.
+- POS template: no `order_token` remnants at all.

--- a/resources/manage/js/views/Events.vue
+++ b/resources/manage/js/views/Events.vue
@@ -43,16 +43,6 @@
 						<router-link :to="{ name: 'menu', params: { id: row.item.id } }">{{ row.item.name }}</router-link>
 					</template>
 
-					<template v-slot:cell(order_token)="row">
-						<!--
-						<a :href="row.item.order_url" target="_blank" title="Client panel">
-							<pre>{{ row.item.order_token }}></pre>
-						</a>
-						-->
-						<input @click="selectOrderToken($event)" :value="row.item.full_order_token" class="order-token"
-							   readonly></input>
-					</template>
-
 					<template v-slot:cell(actions)="row">
 
 						<b-dropdown :text="$t('Actions')" size="sm" right>
@@ -85,6 +75,11 @@
 								<b-dropdown-item :href="row.item.order_url" target="_blank" :title="$t('Client order form')">
 									👤
 									{{ $t('Client order form') }}
+								</b-dropdown-item>
+
+								<b-dropdown-item @click="showOrderToken(row.item)" :title="$t('Remote order token')">
+									🔑
+									{{ $t('Remote order token') }}
 								</b-dropdown-item>
 
 
@@ -204,6 +199,28 @@
 		</template>
 	</b-modal>
 
+	<b-modal :title="$t('Remote order token')" ok-only ref="orderTokenModal">
+		<div v-if="orderTokenEvent">
+			<h5>{{ orderTokenEvent.name }}</h5>
+
+			<b-form-group :label="$t('Order page URL')"
+						  :description="$t('Share this link with your customers to let them order remotely.')">
+				<input @click="selectOrderToken($event)" :value="orderTokenEvent.order_url"
+					   class="form-control order-token" readonly />
+			</b-form-group>
+
+			<b-form-group :label="$t('Order token')">
+				<input @click="selectOrderToken($event)" :value="orderTokenEvent.full_order_token"
+					   class="form-control order-token" readonly />
+			</b-form-group>
+
+			<p class="text-muted small">
+				{{ $t('The order token consists of a public part and a secret part, separated by a dash. The public part identifies the event in the order page URL. The secret part is used by integrating applications, such as QuizWitz, to sign order parameters (card and name) with HMAC-SHA256.') }}
+				{{ $t('Only share the full token with trusted integrations.') }}
+			</p>
+		</div>
+	</b-modal>
+
 </template>
 
 <script>
@@ -232,10 +249,6 @@ export default {
 					label: this.$t('Event'),
 				},
 				{
-					key: 'order_token',
-					label: this.$t('Order token'),
-				},
-				{
 					key: 'is_selling',
 					label: this.$t('Remote orders'),
 					class: 'text-center'
@@ -246,7 +259,8 @@ export default {
 					class: 'text-right'
 				}
 			],
-			model: {}
+			model: {},
+			orderTokenEvent: null
 		}
 	},
 
@@ -319,6 +333,11 @@ export default {
 				payment_cards: true,
 				allow_unpaid_online_orders: false
 			};
+		},
+
+		showOrderToken(event) {
+			this.orderTokenEvent = event;
+			this.$refs.orderTokenModal.show();
 		},
 
 		selectOrderToken(evt) {

--- a/resources/pos/js/views/Events.vue
+++ b/resources/pos/js/views/Events.vue
@@ -39,15 +39,6 @@
 						<router-link :to="{ name: 'hq', params: { id: row.item.id } }">{{ row.item.name }}</router-link>
 					</template>
 
-					<template v-slot:cell(order_token)="row">
-						<!--
-						<a :href="row.item.order_url" target="_blank" title="Client panel">
-							<pre>{{ row.item.order_token }}></pre>
-						</a>
-						-->
-						<input @click="selectOrderToken($event)" :value="row.item.full_order_token" class="order-token" readonly></input>
-					</template>
-
 					<template v-slot:cell(actions)="row">
 
 						<b-dropdown :text="$t('Actions')" size="sm" right>
@@ -209,12 +200,6 @@
 					payment_cards: true,
 					allow_unpaid_online_orders: false
 				};
-			},
-
-			selectOrderToken(evt) {
-				evt.preventDefault();
-				evt.stopPropagation();
-				evt.target.select();
 			}
 
 		}

--- a/resources/shared/js/services/AbstractService.js
+++ b/resources/shared/js/services/AbstractService.js
@@ -60,7 +60,10 @@ export class AbstractService {
 				if (status === 401) {
 					console.log({401:error});
 					window.location.reload();
-					return false;
+
+					// The page is navigating away; keep the request pending so
+					// callers never see a bogus resolved value.
+					return new Promise(() => {});
 				}
 
 				// Handle Forbidden
@@ -68,11 +71,11 @@ export class AbstractService {
 					console.log({403:error});
 					alert(error.message);
 					window.location = window.location.origin;
-					return false;
+					return new Promise(() => {});
 				}
 
 				if (status === 422) {
-					console.log({403:error});
+					console.log({422:error});
 
 					var issues = [];
 					for (var k in error.response.data.error.issues) {
@@ -82,7 +85,7 @@ export class AbstractService {
 					}
 
 					alert(error.response.data.error.message + ': \n' + issues.join(', \n'));
-					return false;
+					return Promise.reject(error);
 				}
 
 				return Promise.reject(error)

--- a/resources/tests/abstract-service-error-interceptor.test.js
+++ b/resources/tests/abstract-service-error-interceptor.test.js
@@ -1,0 +1,105 @@
+/**
+ * Tests for the AbstractService axios error interceptor.
+ *
+ * The interceptor handles 401 (reload), 403 (redirect) and 422 (alert) itself.
+ * It must not resolve the request promise with a bogus value afterwards:
+ * that makes execute() resolve `undefined` and callers like index() crash
+ * with "Cannot read properties of undefined (reading 'items')".
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { AbstractService } from '../shared/js/services/AbstractService';
+
+let requestHandler;
+let reloadMock;
+let locationSetter;
+
+/**
+ * Mimics axios semantics: a rejected request is piped through the
+ * registered error interceptor; whatever the interceptor returns
+ * becomes the result of the request promise.
+ */
+function createService() {
+	let onError = null;
+
+	const client = (config) => requestHandler(config).then(
+		(response) => response,
+		(error) => onError(error)
+	);
+	client.interceptors = {
+		response: {
+			use: vi.fn((success, error) => {
+				onError = error;
+			})
+		}
+	};
+
+	window.axios = { create: vi.fn(() => client) };
+
+	const service = new AbstractService();
+	service.entityUrl = 'devices';
+	service.indexUrl = 'organisations/1/devices';
+	return service;
+}
+
+function httpError(status, data = {}) {
+	return {
+		message: 'Request failed with status code ' + status,
+		response: { status, data }
+	};
+}
+
+/**
+ * Resolves 'pending' if the given promise does not settle within a few ticks.
+ */
+function settlementOf(promise) {
+	return Promise.race([
+		promise.then(() => 'resolved', () => 'rejected'),
+		new Promise((resolve) => setTimeout(() => resolve('pending'), 25))
+	]);
+}
+
+beforeEach(() => {
+	vi.stubGlobal('CATLAB_DRINKS_CONFIG', { API_PATH: '/api/v1' });
+	vi.stubGlobal('alert', vi.fn());
+	delete window.OFFLINE_MANAGER;
+
+	reloadMock = vi.fn();
+	locationSetter = vi.fn();
+	Object.defineProperty(window, 'location', {
+		configurable: true,
+		get: () => ({ reload: reloadMock, origin: 'https://drinks.catlab.eu' }),
+		set: locationSetter
+	});
+});
+
+describe('AbstractService error interceptor', () => {
+	it('reloads and leaves the request pending on 401, so index() never reads items of undefined', async () => {
+		const service = createService();
+		requestHandler = () => Promise.reject(httpError(401));
+
+		expect(await settlementOf(service.index())).toBe('pending');
+		expect(reloadMock).toHaveBeenCalled();
+	});
+
+	it('redirects and leaves the request pending on 403', async () => {
+		const service = createService();
+		requestHandler = () => Promise.reject(httpError(403));
+
+		expect(await settlementOf(service.index())).toBe('pending');
+		expect(locationSetter).toHaveBeenCalledWith('https://drinks.catlab.eu');
+	});
+
+	it('alerts the issues and rejects on 422', async () => {
+		const service = createService();
+		const error = httpError(422, {
+			error: {
+				message: 'Could not save',
+				issues: { name: ['Name is required'] }
+			}
+		});
+		requestHandler = () => Promise.reject(error);
+
+		await expect(service.update(1, { name: '' })).rejects.toBe(error);
+		expect(window.alert).toHaveBeenCalledWith('Could not save: \nName is required');
+	});
+});

--- a/resources/tests/events-views.test.js
+++ b/resources/tests/events-views.test.js
@@ -58,3 +58,48 @@ describe('Manage Events.vue template', () => {
 		expect(template).toContain("name: 'attendees'");
 	});
 });
+
+function readVueFile(appName) {
+	return readFileSync(
+		resolve(__dirname, '..', appName, 'js', 'views', 'Events.vue'),
+		'utf-8'
+	);
+}
+
+describe('Manage Events.vue order token modal', () => {
+	const template = readVueTemplate('manage');
+
+	it('does NOT have an order_token table column', () => {
+		expect(readVueFile('manage')).not.toContain("key: 'order_token'");
+	});
+
+	it('does NOT have an order_token cell slot', () => {
+		expect(template).not.toContain('cell(order_token)');
+	});
+
+	it('has a Remote order token action item', () => {
+		expect(template).toContain('Remote order token');
+	});
+
+	it('has an order token modal', () => {
+		expect(template).toContain('ref="orderTokenModal"');
+	});
+
+	it('shows the full order token in the modal', () => {
+		expect(template).toContain('full_order_token');
+	});
+
+	it('shows the order page URL in the modal', () => {
+		expect(template).toContain('order_url');
+	});
+
+	it('mentions QuizWitz as an integrating client', () => {
+		expect(template).toContain('QuizWitz');
+	});
+});
+
+describe('POS Events.vue order token cleanup', () => {
+	it('has no order_token remnants', () => {
+		expect(readVueFile('pos')).not.toContain('order_token');
+	});
+});


### PR DESCRIPTION
## Summary

Two changes, one per commit:

### 1. Service error interceptor no longer resolves handled errors with `false`

The axios response interceptor in `AbstractService` returned `false` after handling 401/403/422 responses, which *resolved* the request promise. `execute()` turned that into `undefined`, and `index()` crashed with `Cannot read properties of undefined (reading 'items')` — the Airbrake error seen on `/manage/devices`, triggered by the 10-second device poll whenever the session expired.

- **401** → still reloads, now returns a never-settling promise (page is navigating away)
- **403** → still alerts + redirects, same never-settling promise
- **422** → still alerts validation issues, now properly rejects

Fixes the error for every service consumer, since they all share this base class.

### 2. Order token moved out of the Manage events table

The "Order token" column is replaced by a 🔑 **Remote order token** item in the Actions dropdown (Sales group), opening a modal with:

- the order page URL (click-to-select, to share with customers)
- the full order token (click-to-select)
- usage notes on the public/secret token split, naming **QuizWitz** as an integrating client that signs `card`/`name` parameters with the secret

Also removes the dead `order_token` template slot from the POS events view (that column was never rendered there). Design spec: `docs/superpowers/specs/2026-08-05-order-token-modal-design.md`.

## Testing

- New vitest suite `abstract-service-error-interceptor.test.js` (3 tests, written red-first against the production symptom)
- Extended `events-views.test.js` (+8 tests; also fixed the helper so `<script>`-section assertions actually bite)
- Full suites green: vitest 199/199, jest 32/32; webpack dev build compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TDjpPtRZ5RKiUGhs1DtVFH